### PR TITLE
Prevent mutable arguments in interfaces and implementors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@
 * Interface and implementation methods can no longer contain mutable defaults, as this is considered
   a bad practice in general.
 
+* ``Null`` instances are now hashable.
+
 
 0.3.1 (2019-08-16)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-0.3.2 (2019-08-21)
+0.3.2 (2019-08-22)
 ------------------
 
 * Interface and implementation methods can no longer contain mutable defaults, as this is considered

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,10 @@
+0.3.2 (2019-08-21)
+------------------
+
+* Interface and implementation methods can no longer contain mutable defaults, as this is considered
+  a bad practice in general.
+
+
 0.3.1 (2019-08-16)
 ------------------
 

--- a/src/oop_ext/foundation/_tests/test_types.py
+++ b/src/oop_ext/foundation/_tests/test_types.py
@@ -53,6 +53,8 @@ def testNull():
     assert n != 1
     assert n == dummy
 
+    assert hash(Null()) == hash(Null())
+
 
 def testNullCopy():
     n = Null()

--- a/src/oop_ext/foundation/types_.py
+++ b/src/oop_ext/foundation/types_.py
@@ -113,10 +113,6 @@ class Null:
         "Null objects are always false"
         return False
 
-    def __nonzero__(self):
-        # Py 2 compatibility
-        return self.__bool__()
-
     # iter
 
     def __iter__(self):
@@ -127,13 +123,13 @@ class Null:
         "Stop the iteration right now"
         raise StopIteration()
 
-    def next(self):
-        # Py 2 compatibility
-        return self.__next__()
-
     def __eq__(self, o):
         "It is just equal to another Null object."
         return self.__class__ == o.__class__
+
+    def __hash__(self):
+        """Null is hashable"""
+        return 0
 
 
 NULL = Null()  # Create a default instance to be used.

--- a/src/oop_ext/interface/_interface.py
+++ b/src/oop_ext/interface/_interface.py
@@ -480,7 +480,7 @@ class CacheInterfaceAttrs:
             if type(val) in self._ATTRIBUTE_CLASSES:
                 interface_attrs[attr] = val
 
-            if _IsMethod(val, include_functions=True):
+            if _IsMethod(val):
                 interface_methods[attr] = val
 
         return interface_methods, interface_attrs
@@ -511,21 +511,19 @@ class CacheInterfaceAttrs:
 cache_interface_attrs = CacheInterfaceAttrs()
 
 
-def _IsMethod(member, include_functions):
+def _IsMethod(member):
     """
         Consider method the following:
             1) Methods
-            2) Functions (if include_functions is True)
+            2) Functions
             3) instances of Method (should it be implementors of "IMethod"?)
 
     """
-    if include_functions and inspect.isfunction(member):
-        return True
-    elif inspect.ismethod(member):
-        return True
-    elif isinstance(member, Method):
-        return True
-    return False
+    return (
+        inspect.isfunction(member)
+        or inspect.ismethod(member)
+        or isinstance(member, Method)
+    )
 
 
 @Deprecated(AssertImplements)
@@ -611,7 +609,7 @@ def _AssertImplementsFullChecking(class_or_instance, interface, check_attr=True)
     for name in interface_methods:
         try:
             cls_or_obj_method = getattr(class_or_instance, name)
-            if not _IsMethod(cls_or_obj_method, True):
+            if not _IsMethod(cls_or_obj_method):
                 raise AttributeError
 
         except AttributeError:

--- a/src/oop_ext/interface/_tests/test_interface.py
+++ b/src/oop_ext/interface/_tests/test_interface.py
@@ -1,4 +1,4 @@
-
+import re
 import textwrap
 
 import pytest
@@ -18,6 +18,7 @@ from oop_ext.interface import (
     IsImplementation,
     ReadOnlyAttribute,
 )
+from oop_ext import interface
 
 
 class _InterfM1(Interface):
@@ -795,7 +796,6 @@ def test_interface_subclass_mocked(mocker, check_before, autospec):
     :type check_before: bool
     :type autospec: bool
     """
-    from oop_ext import interface
 
     class II(interface.Interface):
         def foo(self, a, b, c):
@@ -818,21 +818,16 @@ def test_interface_subclass_mocked(mocker, check_before, autospec):
 
 
 def testErrorOnInterfaceDeclaration():
-    def Check():
+
+    with pytest.raises(AssertionError):
+
         class Foo:
             pass
 
-        from oop_ext import interface
-
         interface.ImplementsInterface(_InterfM1)(Foo)
-
-    with pytest.raises(AssertionError):
-        Check()
 
 
 def testKeywordOnlyArguments():
-    from oop_ext import interface
-
     class IFoo(interface.Interface):
         def foo(self, x, *, active, enabled=True):
             pass
@@ -847,4 +842,28 @@ def testKeywordOnlyArguments():
         @interface.ImplementsInterface(IFoo)
         class BadFoo:
             def foo(self, x, *, active=False, enabled=True):
+                pass
+
+
+def testHashableArgumentsInterface():
+
+    expected = "Method IFoo.foo contains unhashable arguments:\n" "(self, x=[])"
+    with pytest.raises(TypeError, match=re.escape(expected)):
+
+        class IFoo(interface.Interface):
+            def foo(self, x=[]):
+                pass
+
+
+def testHashableArgumentsImplementation():
+    class IFoo(interface.Interface):
+        def foo(self, x=()):
+            pass
+
+    expected = "Implementation Foo.foo contains unhashable arguments:\n" "(self, x=[])"
+    with pytest.raises(TypeError, match=re.escape(expected)):
+
+        @interface.ImplementsInterface(IFoo)
+        class Foo:
+            def foo(self, x=[]):
                 pass


### PR DESCRIPTION
Also `Null()` is now hashable.