### PR TITLE
Not force implementation declarations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+0.4.0 (2019-12-03)
+==================
+
+* Implementations no longer need to explicitly declare that they declare an interface with ``@ImplementsInterface``: the check is done implicitly (and cached) by `AssertImplements` and equivalent functions.
+
 0.3.2 (2019-08-22)
 ------------------
 

--- a/src/oop_ext/interface/_interface.py
+++ b/src/oop_ext/interface/_interface.py
@@ -317,23 +317,13 @@ def _CheckIfClassImplements(class_, interface):
     from oop_ext.foundation.types_ import Null
 
     if not issubclass(class_, Null):
-        if _IsInterfaceDeclared(class_, interface):
-            # It is required to explicitly declare that the class implements the interface.
-
-            # Since this will only run *once*, a full check is also done here to ensure it is really
-            # implementing.
-            try:
-                _AssertImplementsFullChecking(class_, interface, check_attr=False)
-            except BadImplementationError as e:
-                is_implementation = False
-                from oop_ext.foundation.exceptions import ExceptionToUnicode
-
-                reason = ExceptionToUnicode(e)
-        else:
+        try:
+            _AssertImplementsFullChecking(class_, interface, check_attr=False)
+        except BadImplementationError as e:
             is_implementation = False
-            reason = "The class {} does not declare that it implements the interface {}.".format(
-                class_, interface
-            )
+            from oop_ext.foundation.exceptions import ExceptionToUnicode
+
+            reason = ExceptionToUnicode(e)
 
     result = (is_implementation, reason)
     cache.SetResult((class_, interface), result)

--- a/src/oop_ext/interface/_interface.py
+++ b/src/oop_ext/interface/_interface.py
@@ -863,52 +863,6 @@ def GetImplementedInterfaces(class_or_object):
     return _GetClassImplementedInterfaces(class_)
 
 
-def _IsInterfaceDeclared(class_, interface):
-    """
-        :type interface: Interface or iterable(Interface)
-        :param interface:
-            The target interface(s). If multitple interfaces are passed the method will return True
-            if the given class or instance implements any of the given interfaces.
-
-        :rtype: True if the object declares the interface passed and False otherwise. Note that
-        to declare an interface, the class MUST have declared
-
-            >>> ImplementsInterface(Class)
-    """
-    if class_ is None:
-        return False
-
-    is_collection = False
-    if isinstance(interface, (set, list, tuple)):
-        is_collection = True
-        for i in interface:
-            if not issubclass(i, Interface):
-                raise InterfaceError(
-                    "To check against an interface, an interface is required (received: %s -- mro:%s)"
-                    % (interface, interface.__mro__)
-                )
-    elif not issubclass(interface, Interface):
-        raise InterfaceError(
-            "To check against an interface, an interface is required (received: %s -- mro:%s)"
-            % (interface, interface.__mro__)
-        )
-
-    declared_interfaces = GetImplementedInterfaces(class_)
-
-    # This set will include all interfaces (and its subclasses) declared for the given objec
-    declared_and_subclasses = set()
-    for implemented in declared_interfaces:
-        declared_and_subclasses.update(implemented.__mro__)
-
-    # Discarding object (it will always be returned in the mro collection)
-    declared_and_subclasses.discard(object)
-
-    if not is_collection:
-        return interface in declared_and_subclasses
-    else:
-        return bool(set(interface).intersection(declared_and_subclasses))
-
-
 @Deprecated(AssertImplements)
 def AssertDeclaresInterface(class_or_instance, interface):
     return AssertImplements(class_or_instance, interface)

--- a/src/oop_ext/interface/_tests/test_interface.py
+++ b/src/oop_ext/interface/_tests/test_interface.py
@@ -70,7 +70,8 @@ def testBasics():
     assert IsImplementation(I(C()), I) == True  # OK
 
     assert IsImplementation(C, I) == True  # OK
-    assert IsImplementation(C2, I) == False  # Does not declare
+    # C2 shouldn't need to declare `@ImplementsInterface(I)`
+    assert IsImplementation(C2, I) == True
     assert not IsImplementation(D, I) == True  # nope
 
     assert I(C) is C
@@ -564,15 +565,15 @@ def testAssertImplementsDoesNotDirObject():
 
 def testImplementorWithAny():
     """
-    You must explicitly declare that you implement an Interface.
+    You don't need to explicitly declare that you implement an Interface.
+    This is just a smoke test
     """
 
     class M3:
         def m3(self, *args, **kwargs):
             ""
 
-    with pytest.raises(AssertionError):
-        AssertImplements(M3(), _InterfM3)
+    AssertImplements(M3(), _InterfM3)
 
 
 def testInterfaceCheckRequiresInterface():
@@ -678,21 +679,16 @@ def testDeclareClassImplements():
     with pytest.raises(AssertionError):
         DeclareClassImplements(C0, I1)
 
-    assert IsImplementation(C1, I1) == False
-    with pytest.raises(AssertionError):
-        AssertImplements(C1, I1)
-
-    assert IsImplementation(C12B, I1) == False  # C1 still does not implements I1
+    assert IsImplementation(C1, I1) == True
 
     DeclareClassImplements(C1, I1)
 
     assert IsImplementation(C1, I1) == True
     AssertImplements(C1, I1)
 
-    # C1 is parent of C12B, and, above, it was declared that C1 implements I1, so C12B should
-    # automatically implement I1. But this is not automatic, so you must also declare for it!
-
-    assert IsImplementation(C12B, I1) == False  # not automatic
+    # C1 is parent of C12B, and, above, it was declared that C1 implements I1,
+    # so C12B should automatically implement I1.
+    assert IsImplementation(C12B, I1) == True  # automatic
     assert (
         IsImplementation(C12B, I2) == True
     )  # inheritance for Implements still works automatically

--- a/src/oop_ext/interface/_tests/test_interface.py
+++ b/src/oop_ext/interface/_tests/test_interface.py
@@ -17,6 +17,7 @@ from oop_ext.interface import (
     InterfaceImplementorStub,
     IsImplementation,
     ReadOnlyAttribute,
+    IsImplementationOfAny,
 )
 from oop_ext import interface
 
@@ -863,3 +864,14 @@ def testHashableArgumentsImplementation():
         class Foo:
             def foo(self, x=[]):
                 pass
+
+
+def testIsImplementationOfAny():
+    class A:
+        def m3(self, arg1, arg2):
+            ""
+
+    a_obj = A()
+    AssertImplements(a_obj, _InterfM3)
+    assert IsImplementationOfAny(A, [_InterfM1, _InterfM2, _InterfM3, _InterfM4])
+    assert not IsImplementationOfAny(A, [_InterfM1, _InterfM2, _InterfM4])


### PR DESCRIPTION
Now the final user doesn't need to declare which
interfaces are being implemented, `oop-ext` will
automatically verify if a given class implements
the given interface even if it's not declared.

* Update tests.