### PR TITLE
Add optional argument `requires_declaration`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-0.4.1 (2019-12-12)
+0.5.0 (2019-12-12)
 ==================
 
 * Add optional argument ``requires_declaration`` so users can decide whether or not ``@ImplementsInterface`` declarations are necessary.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,10 @@
-0.4.0 (2019-12-03)
+0.4.1 (2019-12-12)
 ==================
+
+* Add optional argument ``requires_declaration`` so users can decide whether or not ``@ImplementsInterface`` declarations are necessary.
+
+0.4.0 (2019-12-03)
+------------------
 
 * Implementations no longer need to explicitly declare that they declare an interface with ``@ImplementsInterface``: the check is done implicitly (and cached) by `AssertImplements` and equivalent functions.
 

--- a/src/oop_ext/interface/_tests/test_interface.py
+++ b/src/oop_ext/interface/_tests/test_interface.py
@@ -73,6 +73,7 @@ def testBasics():
     assert IsImplementation(C, I) == True  # OK
     # C2 shouldn't need to declare `@ImplementsInterface(I)`
     assert IsImplementation(C2, I) == True
+    assert IsImplementation(C2, I, requires_declaration=True) == False
     assert not IsImplementation(D, I) == True  # nope
 
     assert I(C) is C
@@ -587,6 +588,12 @@ def testInterfaceCheckRequiresInterface():
 
     with pytest.raises(InterfaceError):
         IsImplementation(M3(), M3)
+
+    assert IsImplementation(M3(), _InterfM3, requires_declaration=False)
+    assert not IsImplementation(M3(), _InterfM3, requires_declaration=True)
+
+    with pytest.raises(AssertionError):
+        AssertImplements(M3(), _InterfM3, requires_declaration=True)
 
 
 def testReadOnlyAttribute():


### PR DESCRIPTION
Since version `0.4.0` doesn't require classes to declare
which interfaces are implemented, I'm adding an option
so the final user can decide whether or not declarations
are required.

* Add optional argument `requires_declaration`;
* Cache `requires_declaration`;
* Update tests.