### PR TITLE
Fix `classmethod` mock bug

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,10 @@
-0.5.0 (2019-12-12)
+0.5.1 (2019-12-20)
 ==================
+
+* Fixes an issue (#20) where mocked `classmethods` weren't considered a valid method during internal checks.
+
+0.5.0 (2019-12-12)
+------------------
 
 * Add optional argument ``requires_declaration`` so users can decide whether or not ``@ImplementsInterface`` declarations are necessary.
 

--- a/src/oop_ext/interface/_interface.py
+++ b/src/oop_ext/interface/_interface.py
@@ -590,10 +590,13 @@ def _IsMethod(member):
             3) instances of Method (should it be implementors of "IMethod"?)
 
     """
+    from unittest import mock
+
     return (
         inspect.isfunction(member)
         or inspect.ismethod(member)
         or isinstance(member, Method)
+        or isinstance(member, mock.MagicMock)
     )
 
 

--- a/src/oop_ext/interface/_tests/test_interface.py
+++ b/src/oop_ext/interface/_tests/test_interface.py
@@ -814,11 +814,13 @@ def test_interface_subclass_mocked(mocker, check_before, autospec):
         pass
 
     if check_before:
-        interface.IsImplementation(Bar, II)
+        interface.IsImplementation(Bar, II, requires_declaration=False)
+        interface.IsImplementation(Bar, II, requires_declaration=True)
 
     mocker.patch.object(Foo, "foo", autospec=autospec)
 
-    assert interface.IsImplementation(Bar, II) == (autospec or check_before)
+    assert interface.IsImplementation(Bar, II, requires_declaration=False)
+    assert interface.IsImplementation(Bar, II, requires_declaration=True)
 
 
 def testErrorOnInterfaceDeclaration():
@@ -882,3 +884,23 @@ def testIsImplementationOfAny():
     AssertImplements(a_obj, _InterfM3)
     assert IsImplementationOfAny(A, [_InterfM1, _InterfM2, _InterfM3, _InterfM4])
     assert not IsImplementationOfAny(A, [_InterfM1, _InterfM2, _InterfM4])
+
+
+def testClassMethodBug(mocker):
+    """
+    Issue #20
+    """
+
+    class IFoo(Interface):
+        @classmethod
+        def foo(cls):
+            ""
+
+    @ImplementsInterface(IFoo)
+    class FooImplementation:
+        @classmethod
+        def foo(cls):
+            ""
+
+    mocker.spy(FooImplementation, "foo")
+    AssertImplements(FooImplementation, IFoo, requires_declaration=True)


### PR DESCRIPTION
`unittest.mock` creates a `MagickMock` object when a
`classmethod` is mocked, so we now considered it as a
valid "method" in `_IsMethod` checks.

Fixes #20