### PR TITLE
Callbacks context

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,16 @@
+1.0.0 (2020-10-01)
+------------------
+
+* ``Callbacks`` can be used as context manager, which provides a ``Register(callback, function)``,
+  which automatically unregisters all functions when the context manager ends.
+
+* ``Callback.Register(function)`` now returns an object with a ``Unregister()`` method, which
+  can be used to undo the register call.
+
 0.6.0 (2020-01-31)
 ==================
 
-* Change back the default value of ``requires_declaration`` to ``True`` and fix an error (#22) where the cache wasn 't properly cleared.
+* Change back the default value of ``requires_declaration`` to ``True`` and fix an error (#22) where the cache wasn't properly cleared.
 
 0.5.1 (2019-12-20)
 ------------------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,3 +1,15 @@
 =============
 API Reference
 =============
+
+.. note::
+
+    This page is WIP, PRs are welcome!
+
+.. py:module:: oop_ext.foundation.callback
+
+.. autoclass:: Callback
+    :members:
+
+.. autoclass:: Callbacks
+    :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,7 @@ sys.path.insert(0, os.path.abspath(".."))
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ["sphinx.ext.autodoc", "sphinx.ext.viewcode"]
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.viewcode", "sphinx.ext.napoleon"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,7 +7,6 @@ Welcome to Oop_ext documentation!
 
    readme
    installation
-   usage
    api
    contributing
    changelog

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,7 +1,0 @@
-=====
-Usage
-=====
-
-To use Oop_ext in a project::
-
-    import oop_ext

--- a/environment.devenv.yml
+++ b/environment.devenv.yml
@@ -5,6 +5,7 @@ dependencies:
   - pytest
   - pytest-mock>=1.10
   - python>=3.6
+  - tox
 
 environment:
   PYTHONPATH:

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,4 +5,4 @@ universal = 1
 test = pytest
 
 [tool:pytest]
-collect_ignore = ['setup.py']
+testpaths = src

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with io.open("README.rst", encoding="UTF-8") as readme_file:
 with io.open("CHANGELOG.rst", encoding="UTF-8") as changelog_file:
     history = changelog_file.read()
 
-requirements = []
+requirements = ["attrs"]
 extras_require = {
     "docs": ["sphinx >= 1.4", "sphinx_rtd_theme", "sphinx-autodoc-typehints"],
     "testing": ["codecov", "pytest", "pytest-cov", "pytest-mock", "pre-commit", "tox"],

--- a/src/oop_ext/foundation/callback/_callbacks.py
+++ b/src/oop_ext/foundation/callback/_callbacks.py
@@ -1,4 +1,6 @@
+from typing import Callable, Any, List, Tuple
 
+from ._fast_callback import Callback, _UnregisterContext
 from ._shortcuts import After, Before, Remove
 
 
@@ -10,22 +12,48 @@ class Callbacks:
     collected while still connected in this case.
     """
 
-    def __init__(self):
-        self._callbacks = []
+    def __init__(self) -> None:
+        self._function_callbacks: List[Tuple[Callable, Callable]] = []
+        self._contexts: List[_UnregisterContext] = []
 
     def Before(self, sender, *callbacks, **kwargs):
         sender = Before(sender, *callbacks, **kwargs)
         for callback in callbacks:
-            self._callbacks.append((sender, callback))
+            self._function_callbacks.append((sender, callback))
         return sender
 
     def After(self, sender, *callbacks, **kwargs):
         sender = After(sender, *callbacks, **kwargs)
         for callback in callbacks:
-            self._callbacks.append((sender, callback))
+            self._function_callbacks.append((sender, callback))
         return sender
 
-    def RemoveAll(self):
-        for sender, callback in self._callbacks:
+    def RemoveAll(self) -> None:
+        """
+        Remove all registered functions, either from :meth:`Before`, :meth:`After`, or
+        :meth:`Register`.
+        """
+        for sender, callback in self._function_callbacks:
             Remove(sender, callback)
-        self._callbacks[:] = []
+        self._function_callbacks.clear()
+        for context in self._contexts:
+            context.Unregister()
+        self._contexts.clear()
+
+    def __enter__(self) -> "Callbacks":
+        """Context manager support: when the context ends, unregister all callbacks."""
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
+        """Context manager support: when the context ends, unregister all callbacks."""
+        self.RemoveAll()
+        return False
+
+    def Register(self, callback: Callback, func: Callable[..., Any]) -> None:
+        """
+        Registers the given function into the given callback.
+
+        This will automatically unregister the function from the given callback when
+        RemoveAll() is called or the context manager ends in the context manager form.
+        """
+        self._contexts.append(callback.Register(func))

--- a/src/oop_ext/foundation/callback/_fast_callback.py
+++ b/src/oop_ext/foundation/callback/_fast_callback.py
@@ -23,71 +23,73 @@ class Callback:
     Object that provides a way for others to connect in it and later call it to call
     those connected.
 
-    .. note:: This implementation is improved in that it works directly accessing functions based
-    on a key in an ordered dict, so, Register, Unregister and Contains are much faster than the
-    old callback.
+    .. note::
+        This implementation is improved in that it works directly accessing functions based
+        on a key in an ordered dict, so, Register, Unregister and Contains are much faster than the
+        old callback.
 
-    .. note:: it only stores weakrefs to objects connected
+    .. note:: it only stores weakrefs to objects connected.
 
     .. note::
         After an internal refactoring, ``__slots__`` has been added, so, it cannot have
         weakrefs to it (but as it stores weakrefs internally, that shouldn't be a problem).
         If weakrefs are really needed, ``__weakref__`` should be added to the slots.
 
-    Determining kind of callable (Python 3)
-    ---------------------------------------
+    **Determining kind of callable (Python 3)**
 
     Many parts of callback implementation rely on identifying the kind of callable: is it a
     free function? is it a function bound to an object?
 
     Below there is a table to help understand how different objects are classified:
 
-                        |has__self__|has__call__|has__call__self__|isbuiltin|isfunction|ismethod
-    --------------------|-----------|-----------|-----------------|---------|----------|--------
-    free function       |False      |True       |True             |False    |True      |False
-    bound method        |True       |True       |True             |False    |False     |True
-    class method        |True       |True       |True             |False    |False     |True
-    bound class method  |True       |True       |True             |False    |False     |True
-    function object     |False      |True       |True             |False    |False     |False
-    builtin function    |True       |True       |True             |True     |False     |False
-    object              |True       |True       |True             |True     |False     |False
-    custom object       |False      |False      |False            |False    |False     |False
-    string              |False      |False      |False            |False    |False     |False
+    .. code-block::
+
+                            |has__self__|has__call__|has__call__self__|isbuiltin|isfunction|ismethod
+        --------------------|-----------|-----------|-----------------|---------|----------|--------
+        free function       |False      |True       |True             |False    |True      |False
+        bound method        |True       |True       |True             |False    |False     |True
+        class method        |True       |True       |True             |False    |False     |True
+        bound class method  |True       |True       |True             |False    |False     |True
+        function object     |False      |True       |True             |False    |False     |False
+        builtin function    |True       |True       |True             |True     |False     |False
+        object              |True       |True       |True             |True     |False     |False
+        custom object       |False      |False      |False            |False    |False     |False
+        string              |False      |False      |False            |False    |False     |False
 
     where rows are:
 
-    ```python
-    def free_fn(foo):
-        # `free function`
-        pass
+    .. code-block:: python
 
-    class Foo:
-
-        def bound_fn(self, foo):
+        def free_fn(foo):
+            # `free function`
             pass
 
-    class Bar:
+        class Foo:
 
-        @classmethod
-        def class_fn(cls, foo):
-            pass
+            def bound_fn(self, foo):
+                pass
 
-    class ObjectFn:
+        class Bar:
 
-        def __call__(self, foo):
-            pass
+            @classmethod
+            def class_fn(cls, foo):
+                pass
 
-    foo = Foo()  # foo is `custom object`, foo.bound_fn is `bound method`
-    bar = Bar()  # Bar.class_fn is `class method`, bar.class_fn is `bound class method`
+        class ObjectFn:
 
-    object_fn = ObjectFn()  # `function object`
+            def __call__(self, foo):
+                pass
 
-    obj = object()  # `object`
-    string = 'foo'  # `string`
-    builtin_fn = string.split  # `builtin function`
-    ```
+        foo = Foo()  # foo is `custom object`, foo.bound_fn is `bound method`
+        bar = Bar()  # Bar.class_fn is `class method`, bar.class_fn is `bound class method`
 
-    and where columns are:
+        object_fn = ObjectFn()  # `function object`
+
+        obj = object()  # `object`
+        string = 'foo'  # `string`
+        builtin_fn = string.split  # `builtin function`
+
+    And where columns are:
 
     * isbuiltin: inspect.isbuiltin
     * isfunction: inspect.isfunction

--- a/src/oop_ext/foundation/callback/_fast_callback.py
+++ b/src/oop_ext/foundation/callback/_fast_callback.py
@@ -275,10 +275,12 @@ class Callback:
             using `Callbacks` instead.
         """
         if IsDevelopment() and hasattr(func, "im_class"):
-            # TODO: Python 3 - This can be removed after deprecating Python 2
-            if not inspect.isclass(getattr(func, "im_class")):
-                msg = "%r object has inconsistent internal attributes and is not compatible with " "Callback.\nim_class = %r\n(If using a MagicMock, remember to pass spec=lambda:None)."
-                raise RuntimeError(msg % (func, getattr(func, "im_class")))
+            msg = (
+                "%r object has inconsistent internal attributes and is not compatible with Callback.\n"
+                "im_class = %r\n"
+                "(If using a MagicMock, remember to pass spec=lambda:None)."
+            )
+            raise RuntimeError(msg % (func, getattr(func, "im_class")))
         if extra_args is not self._EXTRA_ARGS_CONSTANT:
             extra_args = tuple(extra_args)
 

--- a/tox.ini
+++ b/tox.ini
@@ -20,10 +20,8 @@ deps = pre-commit>=1.11.0
 commands = pre-commit run --all-files --show-diff-on-failure
 
 [testenv:docs]
-skipsdist = True
 usedevelop = True
 changedir = docs
 extras = docs
-
 commands =
     sphinx-build -W -b html . _build

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py36, linting, docs
 [travis]
 python =
     3.6: py36
-    3.5: py35
+    3.7: py37
 
 [testenv]
 passenv = TOXENV CI TRAVIS TRAVIS_* APPVEYOR APPVEYOR_*


### PR DESCRIPTION
Introduce a way to easily group a bunch of related callbacks to have a way of un-registering them all at the same time.

Also introduced docs for `Callbacks` and `Callback`.