### PR TITLE
Run mypy with pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,9 @@ repos:
         files: ^(CHANGELOG.rst|README.rst)$
         language: python
         additional_dependencies: [pygments, restructuredtext_lint]
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.800
+    hooks:
+    -   id: mypy
+        files: ^(src/)
+        args: []

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,8 @@
+[mypy]
+files = src
+ignore_missing_imports = True
+no_implicit_optional = True
+show_error_codes = True
+strict_equality = True
+warn_redundant_casts = True
+warn_unused_configs = True

--- a/src/oop_ext/foundation/callback/_callbacks.py
+++ b/src/oop_ext/foundation/callback/_callbacks.py
@@ -81,10 +81,9 @@ class Callbacks:
         """Context manager support: when the context ends, unregister all callbacks."""
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb) -> bool:
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
         """Context manager support: when the context ends, unregister all callbacks."""
         self.RemoveAll()
-        return False
 
     def Register(self, callback: Callback, func: Callable[..., Any]) -> None:
         """

--- a/src/oop_ext/foundation/callback/_fast_callback.py
+++ b/src/oop_ext/foundation/callback/_fast_callback.py
@@ -251,10 +251,12 @@ class Callback:
         """
         return to_call
 
-    _EXTRA_ARGS_CONSTANT = tuple()
+    _EXTRA_ARGS_CONSTANT: Tuple[object, ...] = tuple()
 
     def Register(
-        self, func: Callable[..., Any], extra_args: Tuple[object] = _EXTRA_ARGS_CONSTANT
+        self,
+        func: Callable[..., Any],
+        extra_args: Tuple[object, ...] = _EXTRA_ARGS_CONSTANT,
     ) -> "_UnregisterContext":
         """
         Registers a function in the callback.

--- a/src/oop_ext/foundation/callback/_tests/test_callback.py
+++ b/src/oop_ext/foundation/callback/_tests/test_callback.py
@@ -30,7 +30,7 @@ class Stub:
         pass
 
 
-@pytest.yield_fixture(autouse=True)
+@pytest.fixture(autouse=True)
 def restore_test_classes():
     """
     It can't reliably bind callbacks to methods in local temporary classes from Python 3 onward,

--- a/src/oop_ext/foundation/singleton.py
+++ b/src/oop_ext/foundation/singleton.py
@@ -1,4 +1,5 @@
 import threading
+from typing import Type, Set
 
 
 class SingletonError(RuntimeError):
@@ -39,7 +40,7 @@ class Singleton:
     __singleton_stack_start_index = 0
     __lock = threading.RLock()
 
-    _singleton_classes = set()
+    _singleton_classes: Set[Type["Singleton"]] = set()
 
     @staticmethod
     def ResetDefaultSingletonInstances():


### PR DESCRIPTION
This adds the bare minimum type annotations to get mypy running.

It also does not mean that *users* of `oop-ext` will get type checking of
the classes in the library, this will come later as we add more
type annotations.