### PR TITLE
Add type annotations for all modules in oop_ext.foundation

### DIFF
--- a/src/oop_ext/foundation/_tests/test_cached_method.py
+++ b/src/oop_ext/foundation/_tests/test_cached_method.py
@@ -4,74 +4,75 @@ from oop_ext.foundation.cached_method import (
     AttributeBasedCachedMethod,
     CachedMethod,
     LastResultCachedMethod,
+    AbstractCachedMethod,
 )
 
 
-def testCacheMethod(_cached_obj):
-    cache = MyMethod = CachedMethod(_cached_obj.CachedMethod)
+def testCacheMethod(cached_obj: "MyTestObj") -> None:
+    cache = MyMethod = CachedMethod(cached_obj.MyMethod)
 
     MyMethod(1)
-    _cached_obj.CheckCounts(cache, method=1, miss=1)
+    cached_obj.CheckCounts(cache, method=1, miss=1)
 
     MyMethod(1)
-    _cached_obj.CheckCounts(cache, hit=1)
+    cached_obj.CheckCounts(cache, hit=1)
 
     MyMethod(2)
-    _cached_obj.CheckCounts(cache, method=1, miss=1)
+    cached_obj.CheckCounts(cache, method=1, miss=1)
 
     MyMethod(2)
-    _cached_obj.CheckCounts(cache, hit=1)
+    cached_obj.CheckCounts(cache, hit=1)
 
     # ALL results are stored, so these calls are HITs
     MyMethod(1)
-    _cached_obj.CheckCounts(cache, hit=1)
+    cached_obj.CheckCounts(cache, hit=1)
 
     MyMethod(2)
-    _cached_obj.CheckCounts(cache, hit=1)
+    cached_obj.CheckCounts(cache, hit=1)
 
 
-def testCacheMethodEnabled(_cached_obj):
-    cache = MyMethod = CachedMethod(_cached_obj.CachedMethod)
-
-    MyMethod(1)
-    _cached_obj.CheckCounts(cache, method=1, miss=1)
+def testCacheMethodEnabled(cached_obj: "MyTestObj") -> None:
+    cache = MyMethod = CachedMethod(cached_obj.MyMethod)
 
     MyMethod(1)
-    _cached_obj.CheckCounts(cache, hit=1)
+    cached_obj.CheckCounts(cache, method=1, miss=1)
+
+    MyMethod(1)
+    cached_obj.CheckCounts(cache, hit=1)
 
     MyMethod.enabled = False
 
     MyMethod(1)
-    _cached_obj.CheckCounts(cache, method=1, miss=1)
+    cached_obj.CheckCounts(cache, method=1, miss=1)
 
     MyMethod.enabled = True
 
     MyMethod(1)
-    _cached_obj.CheckCounts(cache, hit=1)
+    cached_obj.CheckCounts(cache, hit=1)
 
 
-def testCacheMethodLastResultCachedMethod(_cached_obj):
-    cache = MyMethod = LastResultCachedMethod(_cached_obj.CachedMethod)
-
-    MyMethod(1)
-    _cached_obj.CheckCounts(cache, method=1, miss=1)
+def testCacheMethodLastResultCachedMethod(cached_obj: "MyTestObj") -> None:
+    cache = MyMethod = LastResultCachedMethod(cached_obj.MyMethod)
 
     MyMethod(1)
-    _cached_obj.CheckCounts(cache, hit=1)
+    cached_obj.CheckCounts(cache, method=1, miss=1)
+
+    MyMethod(1)
+    cached_obj.CheckCounts(cache, hit=1)
 
     MyMethod(2)
-    _cached_obj.CheckCounts(cache, method=1, miss=1)
+    cached_obj.CheckCounts(cache, method=1, miss=1)
 
     MyMethod(2)
-    _cached_obj.CheckCounts(cache, hit=1)
+    cached_obj.CheckCounts(cache, hit=1)
 
     # Only the LAST result is stored, so this call is a MISS.
     MyMethod(1)
-    _cached_obj.CheckCounts(cache, method=1, miss=1)
+    cached_obj.CheckCounts(cache, method=1, miss=1)
 
 
-def testCacheMethodObjectInKey(_cached_obj):
-    cache = MyMethod = CachedMethod(_cached_obj.CachedMethod)
+def testCacheMethodObjectInKey(cached_obj: "MyTestObj") -> None:
+    cache = MyMethod = CachedMethod(cached_obj.MyMethod)
 
     class MyObject:
         def __init__(self):
@@ -84,19 +85,19 @@ def testCacheMethodObjectInKey(_cached_obj):
     alpha = MyObject()
 
     MyMethod(alpha)
-    _cached_obj.CheckCounts(cache, method=1, miss=1)
+    cached_obj.CheckCounts(cache, method=1, miss=1)
 
     MyMethod(alpha)
-    _cached_obj.CheckCounts(cache, hit=1)
+    cached_obj.CheckCounts(cache, hit=1)
 
     alpha.name = "bravo"
     alpha.id = 2
 
     MyMethod(alpha)
-    _cached_obj.CheckCounts(cache, method=1, miss=1)
+    cached_obj.CheckCounts(cache, method=1, miss=1)
 
 
-def testCacheMethodAttributeBasedCachedMethod():
+def testCacheMethodAttributeBasedCachedMethod() -> None:
     class TestObject:
         def __init__(self):
             self.name = "alpha"
@@ -108,54 +109,56 @@ def testCacheMethodAttributeBasedCachedMethod():
             return "%s %d" % (par, self.id)
 
     alpha = TestObject()
-    alpha.Foo = AttributeBasedCachedMethod(alpha.Foo, "id", cache_size=3)
-    alpha.Foo("test1")
-    alpha.Foo("test1")
+    alpha.Foo = AttributeBasedCachedMethod(  # type:ignore[assignment]
+        alpha.Foo, "id", cache_size=3
+    )
+    alpha.Foo("test1")  # type:ignore[misc]
+    alpha.Foo("test1")  # type:ignore[misc]
 
     assert alpha.n_calls == 1
 
-    alpha.Foo("test2")
+    alpha.Foo("test2")  # type:ignore[misc]
     assert alpha.n_calls == 2
-    assert len(alpha.Foo._results) == 2
+    assert len(alpha.Foo._results) == 2  # type:ignore[attr-defined]
 
     alpha.id = 3
-    alpha.Foo("test2")
+    alpha.Foo("test2")  # type:ignore[misc]
     assert alpha.n_calls == 3
 
-    assert len(alpha.Foo._results) == 3
+    assert len(alpha.Foo._results) == 3  # type:ignore[attr-defined]
 
-    alpha.Foo("test3")
+    alpha.Foo("test3")  # type:ignore[misc]
     assert alpha.n_calls == 4
-    assert len(alpha.Foo._results) == 3
+    assert len(alpha.Foo._results) == 3  # type:ignore[attr-defined]
 
 
 @pytest.fixture
-def _cached_obj():
+def cached_obj():
     """
     A test_object common to many cached_method tests.
     """
+    return MyTestObj()
 
-    class TestObj:
-        def __init__(self):
-            self.method_count = 0
 
-        def CachedMethod(self, *args, **kwargs):
-            self.method_count += 1
-            return self.method_count
+class MyTestObj:
+    def __init__(self):
+        self.method_count = 0
 
-        def CheckCounts(self, cache, method=0, miss=0, hit=0):
+    def MyMethod(self, *args, **kwargs) -> int:
+        self.method_count += 1
+        return self.method_count
 
-            if not hasattr(cache, "check_counts"):
-                cache.check_counts = dict(method=0, miss=0, hit=0, call=0)
+    def CheckCounts(self, cache, method=0, miss=0, hit=0):
 
-            cache.check_counts["method"] += method
-            cache.check_counts["miss"] += miss
-            cache.check_counts["hit"] += hit
-            cache.check_counts["call"] += miss + hit
+        if not hasattr(cache, "check_counts"):
+            cache.check_counts = dict(method=0, miss=0, hit=0, call=0)
 
-            assert self.method_count == cache.check_counts["method"]
-            assert cache.miss_count == cache.check_counts["miss"]
-            assert cache.hit_count == cache.check_counts["hit"]
-            assert cache.call_count == cache.check_counts["call"]
+        cache.check_counts["method"] += method
+        cache.check_counts["miss"] += miss
+        cache.check_counts["hit"] += hit
+        cache.check_counts["call"] += miss + hit
 
-    return TestObj()
+        assert self.method_count == cache.check_counts["method"]
+        assert cache.miss_count == cache.check_counts["miss"]
+        assert cache.hit_count == cache.check_counts["hit"]
+        assert cache.call_count == cache.check_counts["call"]

--- a/src/oop_ext/foundation/_tests/test_decorators.py
+++ b/src/oop_ext/foundation/_tests/test_decorators.py
@@ -1,4 +1,5 @@
 import warnings
+from typing import Tuple, Any, List
 
 import pytest
 
@@ -6,7 +7,7 @@ from oop_ext.foundation import is_frozen
 from oop_ext.foundation.decorators import Abstract, Deprecated, Implements, Override
 
 
-def testImplements():
+def testImplementsFail() -> None:
     with pytest.raises(AssertionError):
 
         class IFoo:
@@ -18,6 +19,8 @@ def testImplements():
             def DoNotDoIt(self):
                 ""
 
+
+def testImplementsOK() -> None:
     class IFoo:
         def Foo(self):
             """
@@ -35,7 +38,7 @@ def testImplements():
     assert Impl().Foo() == "Impl"
 
 
-def testOverride():
+def testOverride() -> None:
     def TestOK():
         class A:
             def Method(self):
@@ -80,7 +83,7 @@ def testOverride():
         TestNoMatch()
 
 
-def testDeprecated(monkeypatch):
+def testDeprecated(monkeypatch) -> None:
     def MyWarn(*args, **kwargs):
         warn_params.append((args, kwargs))
 
@@ -89,7 +92,7 @@ def testDeprecated(monkeypatch):
     was_development = is_frozen.SetIsDevelopment(True)
     try:
         # Emit messages when in development
-        warn_params = []
+        warn_params: List[Tuple[Any, Any]] = []
 
         # ... deprecation with alternative
         @Deprecated("OtherMethod")
@@ -126,7 +129,7 @@ def testDeprecated(monkeypatch):
         is_frozen.SetIsDevelopment(was_development)
 
 
-def testAbstract():
+def testAbstract() -> None:
     class Alpha:
         @Abstract
         def Method(self):

--- a/src/oop_ext/foundation/_tests/test_immutable.py
+++ b/src/oop_ext/foundation/_tests/test_immutable.py
@@ -5,7 +5,7 @@ import pytest
 from oop_ext.foundation.immutable import AsImmutable, IdentityHashableRef, ImmutableDict
 
 
-def testImmutable():
+def testImmutable() -> None:
     class MyClass:
         pass
 
@@ -67,7 +67,7 @@ def testImmutable():
     assert AsImmutable(MySet()) == frozenset()
 
 
-def testImmutableDict():
+def testImmutableDict() -> None:
     d = ImmutableDict(alpha=1, bravo=2)
 
     with pytest.raises(NotImplementedError):
@@ -89,7 +89,7 @@ def testImmutableDict():
         d.update({"charlie": 3})
 
 
-def testIdentityHashableRef():
+def testIdentityHashableRef() -> None:
     a = {1: 2}
     b = {1: 2}
 

--- a/src/oop_ext/foundation/_tests/test_is_frozen.py
+++ b/src/oop_ext/foundation/_tests/test_is_frozen.py
@@ -6,7 +6,7 @@ from oop_ext.foundation.is_frozen import (
 )
 
 
-def testIsFrozenIsDevelopment():
+def testIsFrozenIsDevelopment() -> None:
     # Note: this test is checking if we're always running tests while not in frozen mode,
     # still, we have to do a try..finally to make sure we restore things to the proper state.
     was_frozen = IsFrozen()

--- a/src/oop_ext/foundation/_tests/test_odict.py
+++ b/src/oop_ext/foundation/_tests/test_odict.py
@@ -1,7 +1,7 @@
 from oop_ext.foundation.odict import odict
 
 
-def testInsert():
+def testInsert() -> None:
     d = odict()
     d[1] = "alpha"
     d[3] = "charlie"
@@ -24,7 +24,7 @@ def testInsert():
     ]
 
 
-def testDelWithSlices():
+def testDelWithSlices() -> None:
     d = odict()
     d[1] = 1
     d[2] = 2

--- a/src/oop_ext/foundation/_tests/test_singleton.py
+++ b/src/oop_ext/foundation/_tests/test_singleton.py
@@ -15,7 +15,7 @@ def CheckCurrentSingleton(singleton_class, value):
     assert singleton.value == value
 
 
-def testSingleton():
+def testSingleton() -> None:
     class MySingleton(Singleton):
         def __init__(self, value):
             self.value = value
@@ -60,7 +60,7 @@ def testSingleton():
         MySingleton.PopSingleton()
 
 
-def testSetSingleton():
+def testSetSingleton() -> None:
     class MySingleton(Singleton):
         def __init__(self, value=None):
             self.value = value
@@ -81,7 +81,7 @@ def testSetSingleton():
         MySingleton.ClearSingleton()
 
 
-def testPushPop():
+def testPushPop() -> None:
     class MySingleton(Singleton):
         def __init__(self, value=None):
             self.value = value
@@ -106,7 +106,7 @@ def testPushPop():
         MySingleton.PopSingleton()
 
 
-def testSingletonOptimization():
+def testSingletonOptimization() -> None:
     class MySingleton(Singleton):
         pass
 
@@ -128,7 +128,7 @@ def testSingletonOptimization():
     assert not obj.called
 
 
-def testGetSingletonThreadSafe(mocker):
+def testGetSingletonThreadSafe(mocker) -> None:
     from threading import Event, Thread
 
     class MySingleton(Singleton):

--- a/src/oop_ext/foundation/_tests/test_types.py
+++ b/src/oop_ext/foundation/_tests/test_types.py
@@ -3,7 +3,7 @@ import copy
 from oop_ext.foundation.types_ import Null
 
 
-def testNull():
+def testNull() -> None:
     # constructing and calling
 
     dummy = Null()
@@ -26,10 +26,10 @@ def testNull():
     n.method1().attr1
 
     n.attr1 = "value"
-    n.attr1.attr2 = "value"
+    n.attr1.attr2 = "value"  # type:ignore[attr-defined]
 
     del n.attr1
-    del n.attr1.attr2.attr3
+    del n.attr1.attr2.attr3  # type:ignore[attr-defined]
 
     # Iteration
     for _ in n:
@@ -55,7 +55,7 @@ def testNull():
     assert hash(Null()) == hash(Null())
 
 
-def testNullCopy():
+def testNullCopy() -> None:
     n = Null()
     n1 = copy.copy(n)
     assert str(n) == str(n1)

--- a/src/oop_ext/foundation/_tests/test_weak_ref.py
+++ b/src/oop_ext/foundation/_tests/test_weak_ref.py
@@ -1,5 +1,6 @@
 import sys
 import weakref
+from typing import Any
 
 import pytest
 
@@ -39,7 +40,7 @@ class Obj:
         return self.name
 
 
-def testStub():
+def testStub() -> None:
     a = _Stub()
     b = _Stub()
     assert not a != a
@@ -49,7 +50,7 @@ def testStub():
     a.Method()
 
 
-def testIsSame():
+def testIsSame() -> None:
     s1 = _Stub()
     s2 = _Stub()
 
@@ -76,14 +77,16 @@ def testIsSame():
         IsSame(p1, p2)
 
 
-def testGetWeakRef():
+def testGetWeakRef() -> None:
     b = GetWeakRef(None)
+    assert callable(b)
     assert b() is None
 
 
-def testGeneral():
+def testGeneral() -> None:
     b = _Stub()
     r = GetWeakRef(b.Method)
+    assert callable(r)
     assert (
         r() is not None
     )  # should not be a regular weak ref here (but a weak method ref)
@@ -92,6 +95,7 @@ def testGeneral():
     assert not IsWeakProxy(r)
 
     r = GetWeakProxy(b.Method)
+    assert callable(r)
     r()
     assert IsWeakProxy(r)
     assert not IsWeakRef(r)
@@ -102,13 +106,13 @@ def testGeneral():
     assert r == r2
     assert hash(r) == hash(r2)
 
-    r = GetWeakRef(b.Method)
-    r2 = GetWeakRef(b.Method)
-    assert r == r2
-    assert hash(r) == hash(r2)
+    r_m1 = GetWeakRef(b.Method)
+    r_m2 = GetWeakRef(b.Method)
+    assert r_m1 == r_m2
+    assert hash(r_m1) == hash(r_m2)
 
 
-def testGetRealObj():
+def testGetRealObj() -> None:
     b = _Stub()
     r = GetWeakRef(b)
     assert GetRealObj(r) is b
@@ -117,15 +121,15 @@ def testGetRealObj():
     assert GetRealObj(r) is None
 
 
-def testGetWeakProxyFromWeakRef():
+def testGetWeakProxyFromWeakRef() -> None:
     b = _Stub()
     r = GetWeakRef(b)
     proxy = GetWeakProxy(r)
     assert IsWeakProxy(proxy)
 
 
-def testWeakSet():
-    weak_set = WeakSet()
+def testWeakSet() -> None:
+    weak_set = WeakSet[Any]()
     s1 = _Stub()
     s2 = _Stub()
 
@@ -156,7 +160,7 @@ def testWeakSet():
     # >>> Testing with FUNCTION
 
     # Adding twice, having one
-    def function():
+    def function() -> None:
         pass
 
     weak_set.add(function)
@@ -164,8 +168,8 @@ def testWeakSet():
     CustomAssertEqual(len(weak_set), 1)
 
 
-def testRemove():
-    weak_set = WeakSet()
+def testRemove() -> None:
+    weak_set = WeakSet[_Stub]()
 
     s1 = _Stub()
 
@@ -181,8 +185,8 @@ def testRemove():
     CustomAssertEqual(len(weak_set), 0)
 
 
-def testWeakSet2():
-    weak_set = WeakSet()
+def testWeakSet2() -> None:
+    weak_set = WeakSet[Any]()
 
     # >>> Removing with DEL
     s1 = _Stub()
@@ -199,8 +203,8 @@ def testWeakSet2():
     CustomAssertEqual(len(weak_set), 0)
 
 
-def testWeakSetUnionWithWeakSet():
-    ws1, ws2 = WeakSet(), WeakSet()
+def testWeakSetUnionWithWeakSet() -> None:
+    ws1, ws2 = WeakSet[Obj](), WeakSet[Obj]()
     a, b, c = Obj("a"), Obj("b"), Obj("c")
 
     ws1.add(a)
@@ -216,8 +220,8 @@ def testWeakSetUnionWithWeakSet():
     assert set(ws3) == set(ws2.union(ws1)) == {a, b}
 
 
-def testWeakSetUnionWithSet():
-    ws = WeakSet()
+def testWeakSetUnionWithSet() -> None:
+    ws = WeakSet[Obj]()
     a, b, c = Obj("a"), Obj("b"), Obj("c")
 
     ws.add(a)
@@ -232,8 +236,8 @@ def testWeakSetUnionWithSet():
     assert set(ws3) == set(s.union(set(ws))) == {a, c}
 
 
-def testWeakSetSubWithWeakSet():
-    ws1, ws2 = WeakSet(), WeakSet()
+def testWeakSetSubWithWeakSet() -> None:
+    ws1, ws2 = WeakSet[Obj](), WeakSet[Obj]()
     a, b, c = Obj("a"), Obj("b"), Obj("c")
 
     ws1.add(a)
@@ -249,8 +253,8 @@ def testWeakSetSubWithWeakSet():
     assert set(ws2 - ws1) == set()
 
 
-def testWeakSetSubWithSet():
-    ws = WeakSet()
+def testWeakSetSubWithSet() -> None:
+    ws = WeakSet[Obj]()
     s = set()
     a, b, c = Obj("a"), Obj("b"), Obj("c")
 
@@ -268,8 +272,8 @@ def testWeakSetSubWithSet():
     assert s - ws == {c}
 
 
-def testWithError():
-    weak_set = WeakSet()
+def testWithError() -> None:
+    weak_set = WeakSet[Any]()
 
     # Not WITH, everything ok
     s1 = _Stub()
@@ -290,10 +294,10 @@ def testWithError():
     CustomAssertEqual(len(weak_set), 0)
 
 
-def testFunction():
-    weak_set = WeakSet()
+def testFunction() -> None:
+    weak_set = WeakSet[Any]()
 
-    def function():
+    def function() -> None:
         "Never called"
 
     # Adding twice, having one.
@@ -318,6 +322,8 @@ def CustomAssertEqual(a, b):
 
 def SetupTestAttributes():
     class C:
+        x: int
+
         def f(self, y=0):
             return self.x + y
 
@@ -332,14 +338,14 @@ def SetupTestAttributes():
     return (C, c, d)
 
 
-def testCustomAssertEqual():
+def testCustomAssertEqual() -> None:
     with pytest.raises(AssertionError) as excinfo:
         CustomAssertEqual(1, 2)
 
     assert str(excinfo.value) == "1 != 2\nassert False"
 
 
-def testRefcount():
+def testRefcount() -> None:
     _, c, _ = SetupTestAttributes()
 
     CustomAssertEqual(
@@ -360,7 +366,7 @@ def testRefcount():
     CustomAssertEqual(sys.getrefcount(c), 2)
 
 
-def testDies():
+def testDies() -> None:
     _, c, _ = SetupTestAttributes()
 
     rf = WeakMethodRef(c.f)
@@ -377,7 +383,7 @@ def testDies():
         pf()
 
 
-def testWorksWithFunctions():
+def testWorksWithFunctions() -> None:
     SetupTestAttributes()
 
     def foo(y):
@@ -392,7 +398,7 @@ def testWorksWithFunctions():
     assert not pf.is_dead()
 
 
-def testWorksWithUnboundMethods():
+def testWorksWithUnboundMethods() -> None:
     C, c, _ = SetupTestAttributes()
 
     meth = C.f
@@ -405,7 +411,7 @@ def testWorksWithUnboundMethods():
     assert not pf.is_dead()
 
 
-def testEq():
+def testEq() -> None:
     _, c, d = SetupTestAttributes()
 
     rf1 = WeakMethodRef(c.f)
@@ -419,7 +425,7 @@ def testEq():
     assert rf1 == rf2
 
 
-def testProxyEq():
+def testProxyEq() -> None:
     _, c, d = SetupTestAttributes()
 
     pf1 = WeakMethodProxy(c.f)
@@ -433,7 +439,7 @@ def testProxyEq():
     assert pf2.is_dead()
 
 
-def testHash():
+def testHash() -> None:
     _, c, _ = SetupTestAttributes()
 
     r = WeakMethodRef(c.f)
@@ -446,21 +452,21 @@ def testHash():
     assert hash(r) == h
 
 
-def testRepr():
+def testRepr() -> None:
     _, c, _ = SetupTestAttributes()
 
     r = WeakMethodRef(c.f)
     assert str(r)[:33] == "<WeakMethodRef to C.f for object "
 
-    def Foo():
+    def Foo() -> None:
         "Never called"
 
     r = WeakMethodRef(Foo)
     assert str(r) == "<WeakMethodRef to Foo>"
 
 
-def testWeakRefToWeakMethodRef():
-    def Foo():
+def testWeakRefToWeakMethodRef() -> None:
+    def Foo() -> None:
         "Never called"
 
     r = WeakMethodRef(Foo)
@@ -468,8 +474,8 @@ def testWeakRefToWeakMethodRef():
     assert m_ref() is r
 
 
-def testWeakList():
-    weak_list = WeakList()
+def testWeakList() -> None:
+    weak_list = WeakList[_Stub]()
     s1 = _Stub()
     s2 = _Stub()
 
@@ -503,7 +509,7 @@ def testWeakList():
 
     assert 0 == len(weak_list[:])
 
-    def m1():
+    def m1() -> None:
         "Never called"
 
     weak_list.append(m1)
@@ -514,9 +520,10 @@ def testWeakList():
     s = _Stub()
     weak_list.append(s.Method)
     assert 1 == len(weak_list[:])
-    s = weakref.ref(s)
+    ref_s = weakref.ref(s)
+    del s
     assert 0 == len(weak_list[:])
-    assert s() is None
+    assert ref_s() is None
 
     s0 = _Stub()
     s1 = _Stub()
@@ -524,8 +531,8 @@ def testWeakList():
     assert len(weak_list) == 2
 
 
-def testSetItem():
-    weak_list = WeakList()
+def testSetItem() -> None:
+    weak_list = WeakList[_Stub]()
     s1 = _Stub()
     s2 = _Stub()
     weak_list.append(s1)

--- a/src/oop_ext/foundation/_tests/test_weak_ref.py
+++ b/src/oop_ext/foundation/_tests/test_weak_ref.py
@@ -512,13 +512,13 @@ def testWeakList() -> None:
     def m1() -> None:
         "Never called"
 
-    weak_list.append(m1)
+    weak_list.append(m1)  # type:ignore[arg-type]
     assert 1 == len(weak_list[:])
     del m1
     assert 0 == len(weak_list[:])
 
     s = _Stub()
-    weak_list.append(s.Method)
+    weak_list.append(s.Method)  # type:ignore[arg-type]
     assert 1 == len(weak_list[:])
     ref_s = weakref.ref(s)
     del s

--- a/src/oop_ext/foundation/cached_method.py
+++ b/src/oop_ext/foundation/cached_method.py
@@ -1,28 +1,44 @@
+# mypy: disallow-untyped-defs
+from abc import abstractmethod
+from typing import (
+    Generic,
+    TypeVar,
+    Callable,
+    Hashable,
+    Optional,
+    Dict,
+    Sequence,
+    Union,
+    cast,
+)
+
 from .immutable import AsImmutable
 from .odict import odict
 from .types_ import Method
 from .weak_ref import WeakMethodRef
 
 
-class AbstractCachedMethod(Method):
+ResultType = TypeVar("ResultType")
+
+
+class AbstractCachedMethod(Method, Generic[ResultType]):
     """
     Base class for cache-manager.
     The abstract class does not implement the storage of results.
     """
 
-    def __init__(self, cached_method=None):
-        # REMARKS: Use WeakMethodRef to avoid cyclic reference.
+    def __init__(self, cached_method: Callable[..., ResultType]) -> None:
+        # Using WeakMethodRef to avoid cyclic reference.
         self._method = WeakMethodRef(cached_method)
         self.enabled = True
         self.ResetCounters()
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args: object, **kwargs: object) -> ResultType:
         key = self.GetCacheKey(*args, **kwargs)
-        result = None
 
         if self.enabled and self._HasResult(key):
             self.hit_count += 1
-            result = self._GetCacheResult(key, result)
+            result = self._GetCacheResult(key, cast(ResultType, None))
         else:
             self.miss_count += 1
             result = self._CallMethod(*args, **kwargs)
@@ -31,10 +47,10 @@ class AbstractCachedMethod(Method):
         self.call_count += 1
         return result
 
-    def _CallMethod(self, *args, **kwargs):
+    def _CallMethod(self, *args: object, **kwargs: object) -> ResultType:
         return self._method()(*args, **kwargs)
 
-    def GetCacheKey(self, *args, **kwargs):
+    def GetCacheKey(self, *args: object, **kwargs: object) -> Hashable:
         """
         Use the arguments to build the cache-key.
         """
@@ -47,94 +63,108 @@ class AbstractCachedMethod(Method):
         if kwargs:
             return AsImmutable(kwargs)
 
-    def _HasResult(self, key):
+        return None
+
+    @abstractmethod
+    def _HasResult(self, key: Hashable) -> bool:
         raise NotImplementedError()
 
-    def _AddCacheResult(self, key, result):
+    @abstractmethod
+    def _AddCacheResult(self, key: Hashable, result: ResultType) -> None:
         raise NotImplementedError()
 
-    def DoClear(self):
+    @abstractmethod
+    def DoClear(self) -> None:
         raise NotImplementedError()
 
-    def Clear(self):
+    def Clear(self) -> None:
         self.DoClear()
         self.ResetCounters()
 
-    def ResetCounters(self):
+    def ResetCounters(self) -> None:
         self.call_count = 0
         self.hit_count = 0
         self.miss_count = 0
 
-    def _GetCacheResult(self, key, result):
+    @abstractmethod
+    def _GetCacheResult(self, key: Hashable, result: ResultType) -> ResultType:
         raise NotImplementedError()
 
 
-class CachedMethod(AbstractCachedMethod):
+class CachedMethod(AbstractCachedMethod, Generic[ResultType]):
     """
     Stores ALL the different results and never delete them.
     """
 
-    def __init__(self, cached_method=None):
+    def __init__(self, cached_method: Callable[..., ResultType]) -> None:
         super().__init__(cached_method)
-        self._results = {}
+        self._results: Dict[Hashable, ResultType] = {}
 
-    def _HasResult(self, key):
+    def _HasResult(self, key: Hashable) -> bool:
         return key in self._results
 
-    def _AddCacheResult(self, key, result):
+    def _AddCacheResult(self, key: Hashable, result: ResultType) -> None:
         self._results[key] = result
 
-    def DoClear(self):
+    def DoClear(self) -> None:
         self._results.clear()
 
-    def _GetCacheResult(self, key, result):
+    def _GetCacheResult(self, key: Hashable, result: ResultType) -> ResultType:
         return self._results[key]
 
 
-class ImmutableParamsCachedMethod(CachedMethod):
+class ImmutableParamsCachedMethod(CachedMethod, Generic[ResultType]):
     """
     Expects all parameters to already be immutable
     Considers only the positional parameters of key, ignoring the keyword arguments
     """
 
-    def GetCacheKey(self, *args, **kwargs):
+    def GetCacheKey(self, *args: object, **kwargs: object) -> Hashable:
         """
         Use the arguments to build the cache-key.
         """
         return args
 
 
-class LastResultCachedMethod(AbstractCachedMethod):
+class LastResultCachedMethod(AbstractCachedMethod, Generic[ResultType]):
     """
     A cache that stores only the last result.
     """
 
-    def __init__(self, cached_method=None):
+    def __init__(self, cached_method: Callable[..., ResultType]) -> None:
         super().__init__(cached_method)
-        self._key = None
-        self._result = None
+        self._key: Optional[object] = None
+        self._result: Optional[ResultType] = None
 
-    def _HasResult(self, key):
+    def _HasResult(self, key: Hashable) -> bool:
         return self._key == key
 
-    def _AddCacheResult(self, key, result):
+    def _AddCacheResult(self, key: Hashable, result: ResultType) -> None:
         self._key = key
         self._result = result
 
-    def DoClear(self):
+    def DoClear(self) -> None:
         self._key = None
         self._result = None
 
-    def _GetCacheResult(self, key, result):
-        return self._result
+    def _GetCacheResult(self, key: Hashable, result: ResultType) -> ResultType:
+        # This could return None (_result is Optional), but not doing an assert
+        # here to avoid breaking code.
+        return self._result  # type:ignore[return-value]
 
 
-class AttributeBasedCachedMethod(CachedMethod):
+class AttributeBasedCachedMethod(CachedMethod, Generic[ResultType]):
     """
     This cached method consider changes in object attributes
     """
 
-    def __init__(self, cached_method, attr_name_list, cache_size=1, results=None):
+    def __init__(
+        self,
+        cached_method: Callable[..., ResultType],
+        attr_name_list: Union[str, Sequence[str]],
+        cache_size: int = 1,
+        results: Optional[odict] = None,
+    ):
         """
         :type cached_method: bound method to be cached
         :param cached_method:
@@ -149,21 +179,21 @@ class AttributeBasedCachedMethod(CachedMethod):
         if isinstance(attr_name_list, str):
             self._attr_name_list = attr_name_list.split()
         else:
-            self._attr_name_list = attr_name_list
+            self._attr_name_list = list(attr_name_list)
         self._cache_size = cache_size
         if results is None:
             self._results = odict()
         else:
             self._results = results
 
-    def GetCacheKey(self, *args, **kwargs):
+    def GetCacheKey(self, *args: object, **kwargs: object) -> Hashable:
         instance = self._method().__self__
         for attr_name in self._attr_name_list:
             kwargs["_object_%s" % attr_name] = getattr(instance, attr_name)
-        return AbstractCachedMethod.GetCacheKey(self, *args, **kwargs)
+        return super().GetCacheKey(*args, **kwargs)
 
-    def _AddCacheResult(self, key, result):
-        CachedMethod._AddCacheResult(self, key, result)
+    def _AddCacheResult(self, key: Hashable, result: ResultType) -> None:
+        super()._AddCacheResult(key, result)
         if len(self._results) > self._cache_size:
             key0 = next(iter(self._results))
             del self._results[key0]

--- a/src/oop_ext/foundation/compat.py
+++ b/src/oop_ext/foundation/compat.py
@@ -1,10 +1,7 @@
+# mypy: disallow-untyped-defs
 """
 A compatibility module for quirks when porting from py2->py3.
 """
-
-
-def __str__(self):
-    return self.__unicode__().encode("utf-8")
 
 
 def GetClassForUnboundMethod(method):

--- a/src/oop_ext/foundation/compat.py
+++ b/src/oop_ext/foundation/compat.py
@@ -2,9 +2,10 @@
 """
 A compatibility module for quirks when porting from py2->py3.
 """
+from typing import Any
 
 
-def GetClassForUnboundMethod(method):
+def GetClassForUnboundMethod(method: Any) -> Any:
     """
     On Python 3 there are no unbound methods anymore. They are only regular functions.
 

--- a/src/oop_ext/foundation/decorators.py
+++ b/src/oop_ext/foundation/decorators.py
@@ -1,12 +1,14 @@
+# mypy: disallow-untyped-defs
 """
 Collection of decorator with ONLY standard library dependencies.
 """
 import warnings
+from typing import Callable, TypeVar, Optional, NoReturn
 
 from oop_ext.foundation.is_frozen import IsDevelopment
 
 
-def Override(method):
+def Override(method: Callable) -> Callable:
     """
     Decorator that marks that a method overrides a method in the superclass.
 
@@ -33,7 +35,7 @@ def Override(method):
             pass
     """
 
-    def Wrapper(func):
+    def Wrapper(func: Callable) -> Callable:
         if func.__name__ != method.__name__:
             msg = "Wrong @Override: %r expected, but overwriting %r."
             msg = msg % (func.__name__, method.__name__)
@@ -47,7 +49,7 @@ def Override(method):
     return Wrapper
 
 
-def Implements(method):
+def Implements(method: Callable) -> Callable:
     """
     Decorator that marks that a method implements a method in some interface.
 
@@ -78,7 +80,7 @@ def Implements(method):
             pass
     """
 
-    def Wrapper(func):
+    def Wrapper(func: Callable) -> Callable:
         if func.__name__ != method.__name__:
             msg = "Wrong @Implements: %r expected, but overwriting %r."
             msg = msg % (func.__name__, method.__name__)
@@ -92,35 +94,36 @@ def Implements(method):
     return Wrapper
 
 
-def Deprecated(name=None):
+def Deprecated(what: Optional[object] = None) -> Callable:
     """
     Decorator that marks a method as deprecated.
 
-    :param str name:
-        The name of the method that substitutes this one, if any.
+    :param what:
+        Method that replaces the deprecated method, if any. Here it is common to pass
+        either a function or the name of the method.
     """
     if not IsDevelopment():
         # Optimization: we don't want deprecated to add overhead in release mode.
 
-        def DeprecatedDecorator(func):
+        def DeprecatedDecorator(func: Callable) -> Callable:
             return func
 
     else:
 
-        def DeprecatedDecorator(func):
+        def DeprecatedDecorator(func: Callable) -> Callable:
             """
             The actual deprecated decorator, configured with the name parameter.
             """
 
-            def DeprecatedWrapper(*args, **kwargs):
+            def DeprecatedWrapper(*args: object, **kwargs: object) -> object:
                 """
                 This method wrapper gives a deprecated message before calling the original
                 implementation.
                 """
-                if name is not None:
+                if what is not None:
                     msg = "DEPRECATED: '%s' is deprecated, use '%s' instead" % (
                         func.__name__,
-                        name,
+                        what,
                     )
                 else:
                     msg = "DEPRECATED: '%s' is deprecated" % func.__name__
@@ -134,7 +137,7 @@ def Deprecated(name=None):
     return DeprecatedDecorator
 
 
-def Abstract(func):
+def Abstract(func: Callable) -> Callable:
     '''
     Decorator to make methods 'abstract', which are meant to be overwritten in subclasses. If some
     subclass doesn't override the method, it will raise NotImplementedError when called. Note that
@@ -160,7 +163,7 @@ def Abstract(func):
 
     '''
 
-    def AbstractWrapper(self, *args, **kwargs):
+    def AbstractWrapper(self: object, *args: object, **kwargs: object) -> NoReturn:
         """
         This wrapper method replaces the implementation of the (abstract) method, providing a
         friendly message to the user.

--- a/src/oop_ext/foundation/decorators.py
+++ b/src/oop_ext/foundation/decorators.py
@@ -3,12 +3,16 @@
 Collection of decorator with ONLY standard library dependencies.
 """
 import warnings
-from typing import Callable, TypeVar, Optional, NoReturn
+from typing import Callable, Optional, NoReturn, TypeVar, Any, TYPE_CHECKING, cast
 
 from oop_ext.foundation.is_frozen import IsDevelopment
 
 
-def Override(method: Callable) -> Callable:
+F = TypeVar("F", bound=Callable[..., Any])
+G = TypeVar("G", bound=Callable[..., Any])
+
+
+def Override(method: G) -> Callable[[F], F]:
     """
     Decorator that marks that a method overrides a method in the superclass.
 
@@ -35,7 +39,7 @@ def Override(method: Callable) -> Callable:
             pass
     """
 
-    def Wrapper(func: Callable) -> Callable:
+    def Wrapper(func: F) -> F:
         if func.__name__ != method.__name__:
             msg = "Wrong @Override: %r expected, but overwriting %r."
             msg = msg % (func.__name__, method.__name__)
@@ -49,7 +53,7 @@ def Override(method: Callable) -> Callable:
     return Wrapper
 
 
-def Implements(method: Callable) -> Callable:
+def Implements(method: G) -> Callable[[F], F]:
     """
     Decorator that marks that a method implements a method in some interface.
 
@@ -91,10 +95,10 @@ def Implements(method: Callable) -> Callable:
 
         return func
 
-    return Wrapper
+    return cast(Callable[[F], F], Wrapper)
 
 
-def Deprecated(what: Optional[object] = None) -> Callable:
+def Deprecated(what: Optional[object] = None) -> Callable[[F], F]:
     """
     Decorator that marks a method as deprecated.
 
@@ -134,10 +138,10 @@ def Deprecated(what: Optional[object] = None) -> Callable:
             DeprecatedWrapper.__doc__ = func.__doc__
             return DeprecatedWrapper
 
-    return DeprecatedDecorator
+    return cast(Callable[[F], F], DeprecatedDecorator)
 
 
-def Abstract(func: Callable) -> Callable:
+def Abstract(func: F) -> F:
     '''
     Decorator to make methods 'abstract', which are meant to be overwritten in subclasses. If some
     subclass doesn't override the method, it will raise NotImplementedError when called. Note that
@@ -179,4 +183,4 @@ def Abstract(func: Callable) -> Callable:
     # # pylint: disable-msg=W0622
     AbstractWrapper.__name__ = func.__name__
     AbstractWrapper.__doc__ = func.__doc__
-    return AbstractWrapper
+    return cast(F, AbstractWrapper)

--- a/src/oop_ext/foundation/exceptions.py
+++ b/src/oop_ext/foundation/exceptions.py
@@ -1,4 +1,8 @@
-def ExceptionToUnicode(exception):
+# mypy: disallow-untyped-defs
+from typing import Optional
+
+
+def ExceptionToUnicode(exception: Exception) -> str:
     """
     Python 3 exception handling already deals with string error messages. Here we
     will only append the original exception message to the returned message (this is automatically done in Python 2
@@ -6,7 +10,8 @@ def ExceptionToUnicode(exception):
     as a separated attribute
     """
     messages = []
-    while exception:
-        messages.append(str(exception))
-        exception = exception.__cause__ or exception.__context__
+    exc: Optional[BaseException] = exception
+    while exc:
+        messages.append(str(exc))
+        exc = exc.__cause__ or exc.__context__
     return "\n".join(messages)

--- a/src/oop_ext/foundation/is_frozen.py
+++ b/src/oop_ext/foundation/is_frozen.py
@@ -1,5 +1,3 @@
-import sys
-
 """
 frozen
 Setup the sys.frozen attribute when the application is not in release mode.
@@ -8,11 +6,12 @@ This attribute is automatically set when the source code is in an executable.
 Use "IsFrozen" instead of "sys.frozen == False" because some libraries (pywin32) checks for the
 attribute existence, not the value.
 """
+import sys
 
 _is_frozen = hasattr(sys, "frozen") and getattr(sys, "frozen")
 
 
-def IsFrozen():
+def IsFrozen() -> bool:
     """
     Returns true if the code is frozen, that is, the code is inside a generated executable.
 
@@ -22,7 +21,7 @@ def IsFrozen():
     return _is_frozen
 
 
-def SetIsFrozen(is_frozen):
+def SetIsFrozen(is_frozen: bool) -> bool:
     """
     Sets the is_frozen value manually, overriding the "calculated" value.
 
@@ -42,7 +41,7 @@ def SetIsFrozen(is_frozen):
 _is_development = not _is_frozen
 
 
-def IsDevelopment():
+def IsDevelopment() -> bool:
     """
     This function is used to indentify if we're in a development environment or production
     environment.
@@ -60,7 +59,7 @@ def IsDevelopment():
     return _is_development
 
 
-def SetIsDevelopment(is_development):
+def SetIsDevelopment(is_development: bool) -> bool:
     """
     :param bool is_development:
         The new is-development value, which is returned by ..seealso:: IsDevelopment.

--- a/src/oop_ext/foundation/odict.py
+++ b/src/oop_ext/foundation/odict.py
@@ -1,8 +1,16 @@
+# mypy: disallow-untyped-defs
 import collections
+from typing import Any, Iterable, Hashable, Union
 
 
-class _OrderedDict(collections.OrderedDict):
-    def insert(self, index, key, value, dict_setitem=dict.__setitem__):
+class odict(collections.OrderedDict):
+    def insert(
+        self,
+        index: int,
+        key: Hashable,
+        value: Any,
+        dict_setitem: Any = dict.__setitem__,
+    ) -> None:
         """
         Convenience method to have same interface as `ruamel.ordereddict`, which as traditionally
         used on Python 2.
@@ -14,6 +22,7 @@ class _OrderedDict(collections.OrderedDict):
         #
         # Note that `move_to_end` is a O(1) operation that just swaps endpoints of underlying
         # double linked list maintained by C-extension ordered dict.
+        moved: Iterable[Any]
         if (len(self) - index) <= (len(self) // 2):
             moved = [k for i, k in enumerate(self.keys()) if i >= index and k != key]
             last = True
@@ -21,11 +30,12 @@ class _OrderedDict(collections.OrderedDict):
             moved = reversed(
                 [k for i, k in enumerate(self.keys()) if i < index or k == key]
             )
+
             last = False
         for k in moved:
             self.move_to_end(k, last=last)
 
-    def __delitem__(self, key):
+    def __delitem__(self, key: Union[Hashable, slice]) -> None:
         if isinstance(key, slice):
             # Properly deal with slices (based on order).
             keys = list(self.keys())
@@ -34,6 +44,3 @@ class _OrderedDict(collections.OrderedDict):
 
         else:
             collections.OrderedDict.__delitem__(self, key)
-
-
-odict = _OrderedDict

--- a/src/oop_ext/foundation/types_.py
+++ b/src/oop_ext/foundation/types_.py
@@ -1,7 +1,8 @@
+# mypy: disallow-untyped-defs
 """
 Extensions to python native types.
 """
-from typing import TYPE_CHECKING, Any, NoReturn, Iterator
+from typing import TYPE_CHECKING, Any, NoReturn, Iterator, TypeVar
 
 if TYPE_CHECKING:
     from typing_extensions import Literal
@@ -12,6 +13,9 @@ class Method:
     This class is an 'organization' class, so that subclasses are considered as methods
     (and its __call__ method is checked for the parameters)
     """
+
+
+T = TypeVar("T")
 
 
 class Null:
@@ -97,7 +101,7 @@ class Null:
     def __delattr__(self, _name: str) -> None:
         "Ignore deleting attributes."
 
-    def __enter__(self) -> Any:
+    def __enter__(self: T) -> T:
         return self
 
     def __exit__(self, *args: object, **kwargs: object) -> None:
@@ -117,15 +121,15 @@ class Null:
 
     # iter
 
-    def __iter__(self) -> Iterator[Any]:
+    def __iter__(self: T) -> Iterator[T]:
         "I will stop it in the first iteration"
-        return self
+        return iter([self])
 
     def __next__(self) -> NoReturn:
         "Stop the iteration right now"
         raise StopIteration()
 
-    def __eq__(self, o) -> Any:
+    def __eq__(self, o: Any) -> Any:
         "It is just equal to another Null object."
         return self.__class__ == o.__class__
 

--- a/src/oop_ext/foundation/types_.py
+++ b/src/oop_ext/foundation/types_.py
@@ -1,6 +1,10 @@
 """
 Extensions to python native types.
 """
+from typing import TYPE_CHECKING, Any, NoReturn, Iterator
+
+if TYPE_CHECKING:
+    from typing_extensions import Literal
 
 
 class Method:
@@ -65,17 +69,16 @@ class Null:
 
     # object constructing
 
-    def __init__(self, *_args, **_kwargs):
+    def __init__(self, *_args: object, **_kwargs: object) -> None:
         "Ignore parameters."
         # Setting the name of what's gotten (so that __name__ is properly preserved).
         self.__dict__["_Null__name__"] = "Null"
-        return None
 
-    def __call__(self, *_args, **_kwargs):
+    def __call__(self, *_args: object, **_kwargs: object) -> "Null":
         "Ignore method calls."
         return self
 
-    def __getattr__(self, mname):
+    def __getattr__(self, mname: str) -> Any:
         "Ignore attribute requests."
         if mname == "__getnewargs__":
             raise AttributeError(
@@ -87,47 +90,46 @@ class Null:
 
         return self
 
-    def __setattr__(self, _name, _value):
+    def __setattr__(self, _name: str, _value: object) -> Any:
         "Ignore attribute setting."
         return self
 
-    def __delattr__(self, _name):
+    def __delattr__(self, _name: str) -> None:
         "Ignore deleting attributes."
+
+    def __enter__(self) -> Any:
         return self
 
-    def __enter__(self):
-        return self
+    def __exit__(self, *args: object, **kwargs: object) -> None:
+        pass
 
-    def __exit__(self, *args, **kwargs):
-        return self
-
-    def __repr__(self):
+    def __repr__(self) -> str:
         "Return a string representation."
         return "<Null>"
 
-    def __str__(self):
+    def __str__(self) -> str:
         "Convert to a string and return it."
         return "Null"
 
-    def __bool__(self):
+    def __bool__(self) -> "Literal[False]":
         "Null objects are always false"
         return False
 
     # iter
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Any]:
         "I will stop it in the first iteration"
         return self
 
-    def __next__(self):
+    def __next__(self) -> NoReturn:
         "Stop the iteration right now"
         raise StopIteration()
 
-    def __eq__(self, o):
+    def __eq__(self, o) -> Any:
         "It is just equal to another Null object."
         return self.__class__ == o.__class__
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         """Null is hashable"""
         return 0
 

--- a/src/oop_ext/foundation/types_.py
+++ b/src/oop_ext/foundation/types_.py
@@ -15,9 +15,6 @@ class Method:
     """
 
 
-T = TypeVar("T")
-
-
 class Null:
     """
     This is a sample implementation of the 'Null Object' design pattern.
@@ -101,7 +98,7 @@ class Null:
     def __delattr__(self, _name: str) -> None:
         "Ignore deleting attributes."
 
-    def __enter__(self: T) -> T:
+    def __enter__(self) -> "Null":
         return self
 
     def __exit__(self, *args: object, **kwargs: object) -> None:
@@ -121,7 +118,7 @@ class Null:
 
     # iter
 
-    def __iter__(self: T) -> Iterator[T]:
+    def __iter__(self) -> Iterator["Null"]:
         "I will stop it in the first iteration"
         return iter([self])
 


### PR DESCRIPTION
This still doesn't enable users to use the type-annotations themselves, but is a step in that direction.