### PR TITLE
Fix callback.After no longer invalidating interface signatures in implementations

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,10 @@
+1.1.2 (2021-02-23)
+------------------
+
+* #41: Fix regression introduced in ``1.1.0`` where installing a callback using
+  ``callback.After`` or ``callback.Before`` would make a method no longer compliant with
+  the signature required by its interface.
+
 1.1.1 (2021-02-23)
 ------------------
 

--- a/src/oop_ext/foundation/decorators.py
+++ b/src/oop_ext/foundation/decorators.py
@@ -169,7 +169,7 @@ def Abstract(func: F) -> F:
 
     # Make sure to use one of the valid general signatures accepted by AssertImplements
     # so this decorator can be used in interface implementations.
-    def AbstractWrapper(self: object, *args: object, **kwargs: object) -> object:
+    def AbstractWrapper(self: object, *args: object, **kwargs: object) -> NoReturn:
         """
         This wrapper method replaces the implementation of the (abstract) method, providing a
         friendly message to the user.

--- a/src/oop_ext/interface/_interface.py
+++ b/src/oop_ext/interface/_interface.py
@@ -1067,7 +1067,7 @@ def _GetGenericImplementationSignatures() -> Set[inspect.Signature]:
     def func3(cls, *args, **kwargs):  # type:ignore[no-untyped-def]
         ...
 
-    def func4(*args: object, **kwargs: object) -> object:  # type:ignore[no-untyped-def]
+    def func4(*args: object, **kwargs: object) -> object:
         ...
 
     def func5(  # type:ignore[no-untyped-def]
@@ -1086,6 +1086,48 @@ def _GetGenericImplementationSignatures() -> Set[inspect.Signature]:
     def func8(cls: object, *args: object, **kwargs: object) -> object:
         ...
 
+    def func9(  # type:ignore[no-untyped-def]
+        *args: object, **kwargs: object
+    ) -> Any:
+        ...
+
+    def func10(  # type:ignore[no-untyped-def]
+        self, *args: object, **kwargs: object
+    ) -> Any:
+        ...
+
+    def func11(  # type:ignore[no-untyped-def]
+        cls, *args: object, **kwargs: object
+    ) -> Any:
+        ...
+
+    def func12(self: object, *args: object, **kwargs: object) -> Any:
+        ...
+
+    def func13(cls: object, *args: object, **kwargs: object) -> Any:
+        ...
+
+    def func14(  # type:ignore[no-untyped-def]
+        *args: object, **kwargs: object
+    ) -> NoReturn:
+        ...
+
+    def func15(  # type:ignore[no-untyped-def]
+        self, *args: object, **kwargs: object
+    ) -> NoReturn:
+        ...
+
+    def func16(  # type:ignore[no-untyped-def]
+        cls, *args: object, **kwargs: object
+    ) -> NoReturn:
+        ...
+
+    def func17(self: object, *args: object, **kwargs: object) -> NoReturn:
+        ...
+
+    def func18(cls: object, *args: object, **kwargs: object) -> NoReturn:
+        ...
+
     _GENERIC_IMPLEMENTATION_SIGNATURES = {
         inspect.Signature.from_callable(func1),
         inspect.Signature.from_callable(func2),
@@ -1095,5 +1137,15 @@ def _GetGenericImplementationSignatures() -> Set[inspect.Signature]:
         inspect.Signature.from_callable(func6),
         inspect.Signature.from_callable(func7),
         inspect.Signature.from_callable(func8),
+        inspect.Signature.from_callable(func9),
+        inspect.Signature.from_callable(func10),
+        inspect.Signature.from_callable(func11),
+        inspect.Signature.from_callable(func12),
+        inspect.Signature.from_callable(func13),
+        inspect.Signature.from_callable(func14),
+        inspect.Signature.from_callable(func15),
+        inspect.Signature.from_callable(func16),
+        inspect.Signature.from_callable(func17),
+        inspect.Signature.from_callable(func18),
     }
     return _GENERIC_IMPLEMENTATION_SIGNATURES


### PR DESCRIPTION
Fix #41