### PR TITLE
Add reorder-python-imports pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,11 @@ repos:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
     -   id: debug-statements
+-   repo: https://github.com/asottile/reorder_python_imports
+    rev: v2.6.0
+    hooks:
+    -   id: reorder-python-imports
+        args: ['--application-directories=.:src', --py36-plus]
 -   repo: local
     hooks:
     -   id: rst

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,6 @@
 #
 # All configuration values have a default; values that are commented out
 # serve to show the default.
-
 # If extensions (or modules to document with autodoc) are in another
 # directory, add these directories to sys.path here. If the directory is
 # relative to the documentation root, use os.path.abspath to make it

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
 """The setup script."""
-
 import io
-from setuptools import find_packages, setup
+
+from setuptools import find_packages
+from setuptools import setup
 
 with io.open("README.rst", encoding="UTF-8") as readme_file:
     readme = readme_file.read()

--- a/src/oop_ext/_type_checker_fixture.py
+++ b/src/oop_ext/_type_checker_fixture.py
@@ -2,13 +2,13 @@
 # mypy: disallow-any-decorated
 import os
 import re
-from textwrap import dedent
-
-import mypy.api
 from pathlib import Path
-from typing import List, Tuple
+from textwrap import dedent
+from typing import List
+from typing import Tuple
 
 import attr
+import mypy.api
 import pytest
 
 

--- a/src/oop_ext/conftest.py
+++ b/src/oop_ext/conftest.py
@@ -1,5 +1,4 @@
 # mypy: disallow-untyped-defs
-
 from pathlib import Path
 from typing import TYPE_CHECKING
 

--- a/src/oop_ext/foundation/_tests/test_cached_method.py
+++ b/src/oop_ext/foundation/_tests/test_cached_method.py
@@ -1,11 +1,9 @@
 import pytest
 
-from oop_ext.foundation.cached_method import (
-    AttributeBasedCachedMethod,
-    CachedMethod,
-    LastResultCachedMethod,
-    AbstractCachedMethod,
-)
+from oop_ext.foundation.cached_method import AbstractCachedMethod
+from oop_ext.foundation.cached_method import AttributeBasedCachedMethod
+from oop_ext.foundation.cached_method import CachedMethod
+from oop_ext.foundation.cached_method import LastResultCachedMethod
 
 
 def testCacheMethod(cached_obj: "MyTestObj") -> None:

--- a/src/oop_ext/foundation/_tests/test_decorators.py
+++ b/src/oop_ext/foundation/_tests/test_decorators.py
@@ -1,10 +1,15 @@
 import warnings
-from typing import Tuple, Any, List
+from typing import Any
+from typing import List
+from typing import Tuple
 
 import pytest
 
 from oop_ext.foundation import is_frozen
-from oop_ext.foundation.decorators import Abstract, Deprecated, Implements, Override
+from oop_ext.foundation.decorators import Abstract
+from oop_ext.foundation.decorators import Deprecated
+from oop_ext.foundation.decorators import Implements
+from oop_ext.foundation.decorators import Override
 
 
 def testImplementsFail() -> None:

--- a/src/oop_ext/foundation/_tests/test_immutable.py
+++ b/src/oop_ext/foundation/_tests/test_immutable.py
@@ -1,8 +1,11 @@
-from copy import copy, deepcopy
+from copy import copy
+from copy import deepcopy
 
 import pytest
 
-from oop_ext.foundation.immutable import AsImmutable, IdentityHashableRef, ImmutableDict
+from oop_ext.foundation.immutable import AsImmutable
+from oop_ext.foundation.immutable import IdentityHashableRef
+from oop_ext.foundation.immutable import ImmutableDict
 
 
 def testImmutable() -> None:

--- a/src/oop_ext/foundation/_tests/test_is_frozen.py
+++ b/src/oop_ext/foundation/_tests/test_is_frozen.py
@@ -1,9 +1,7 @@
-from oop_ext.foundation.is_frozen import (
-    IsDevelopment,
-    IsFrozen,
-    SetIsDevelopment,
-    SetIsFrozen,
-)
+from oop_ext.foundation.is_frozen import IsDevelopment
+from oop_ext.foundation.is_frozen import IsFrozen
+from oop_ext.foundation.is_frozen import SetIsDevelopment
+from oop_ext.foundation.is_frozen import SetIsFrozen
 
 
 def testIsFrozenIsDevelopment() -> None:

--- a/src/oop_ext/foundation/_tests/test_singleton.py
+++ b/src/oop_ext/foundation/_tests/test_singleton.py
@@ -2,12 +2,10 @@ import pytest
 
 from oop_ext.foundation.callback import After
 from oop_ext.foundation.decorators import Override
-from oop_ext.foundation.singleton import (
-    PushPopSingletonError,
-    Singleton,
-    SingletonAlreadySetError,
-    SingletonNotSetError,
-)
+from oop_ext.foundation.singleton import PushPopSingletonError
+from oop_ext.foundation.singleton import Singleton
+from oop_ext.foundation.singleton import SingletonAlreadySetError
+from oop_ext.foundation.singleton import SingletonNotSetError
 
 
 def CheckCurrentSingleton(singleton_class, value):

--- a/src/oop_ext/foundation/_tests/test_weak_ref.py
+++ b/src/oop_ext/foundation/_tests/test_weak_ref.py
@@ -4,18 +4,16 @@ from typing import Any
 
 import pytest
 
-from oop_ext.foundation.weak_ref import (
-    GetRealObj,
-    GetWeakProxy,
-    GetWeakRef,
-    IsSame,
-    IsWeakProxy,
-    IsWeakRef,
-    WeakList,
-    WeakMethodProxy,
-    WeakMethodRef,
-    WeakSet,
-)
+from oop_ext.foundation.weak_ref import GetRealObj
+from oop_ext.foundation.weak_ref import GetWeakProxy
+from oop_ext.foundation.weak_ref import GetWeakRef
+from oop_ext.foundation.weak_ref import IsSame
+from oop_ext.foundation.weak_ref import IsWeakProxy
+from oop_ext.foundation.weak_ref import IsWeakRef
+from oop_ext.foundation.weak_ref import WeakList
+from oop_ext.foundation.weak_ref import WeakMethodProxy
+from oop_ext.foundation.weak_ref import WeakMethodRef
+from oop_ext.foundation.weak_ref import WeakSet
 
 
 class _Stub:

--- a/src/oop_ext/foundation/cached_method.py
+++ b/src/oop_ext/foundation/cached_method.py
@@ -1,16 +1,14 @@
 # mypy: disallow-untyped-defs
 from abc import abstractmethod
-from typing import (
-    Generic,
-    TypeVar,
-    Callable,
-    Hashable,
-    Optional,
-    Dict,
-    Sequence,
-    Union,
-    cast,
-)
+from typing import Callable
+from typing import cast
+from typing import Dict
+from typing import Generic
+from typing import Hashable
+from typing import Optional
+from typing import Sequence
+from typing import TypeVar
+from typing import Union
 
 from .immutable import AsImmutable
 from .odict import odict

--- a/src/oop_ext/foundation/callback/__init__.py
+++ b/src/oop_ext/foundation/callback/__init__.py
@@ -1,15 +1,16 @@
-from ._callbacks import Callbacks
 from ._callback import Callback
-from ._typed_callback import (
-    Callback0,
-    Callback1,
-    Callback2,
-    Callback3,
-    Callback4,
-    Callback5,
-)
+from ._callbacks import Callbacks
 from ._priority_callback import PriorityCallback
-from ._shortcuts import After, Before, Remove, WrapForCallback
+from ._shortcuts import After
+from ._shortcuts import Before
+from ._shortcuts import Remove
+from ._shortcuts import WrapForCallback
+from ._typed_callback import Callback0
+from ._typed_callback import Callback1
+from ._typed_callback import Callback2
+from ._typed_callback import Callback3
+from ._typed_callback import Callback4
+from ._typed_callback import Callback5
 
 __all__ = [
     "Callbacks",

--- a/src/oop_ext/foundation/callback/_callback.py
+++ b/src/oop_ext/foundation/callback/_callback.py
@@ -54,7 +54,14 @@ import inspect
 import logging
 import types
 import weakref
-from typing import Callable, Any, Tuple, Hashable, Sequence, Union, cast, Optional
+from typing import Any
+from typing import Callable
+from typing import cast
+from typing import Hashable
+from typing import Optional
+from typing import Sequence
+from typing import Tuple
+from typing import Union
 
 import attr
 

--- a/src/oop_ext/foundation/callback/_callbacks.py
+++ b/src/oop_ext/foundation/callback/_callbacks.py
@@ -1,9 +1,17 @@
 # mypy: disallow-untyped-defs
 # mypy: disallow-any-decorated
-from typing import Callable, Any, List, Tuple, TypeVar, cast
+from typing import Any
+from typing import Callable
+from typing import cast
+from typing import List
+from typing import Tuple
+from typing import TypeVar
 
-from ._callback import Callback, _UnregisterContext
-from ._shortcuts import After, Before, Remove
+from ._callback import _UnregisterContext
+from ._callback import Callback
+from ._shortcuts import After
+from ._shortcuts import Before
+from ._shortcuts import Remove
 
 
 T = TypeVar("T", bound=Callable)

--- a/src/oop_ext/foundation/callback/_priority_callback.py
+++ b/src/oop_ext/foundation/callback/_priority_callback.py
@@ -1,11 +1,12 @@
 # mypy: disallow-untyped-defs
 # mypy: disallow-any-decorated
-from typing import Callable, Any, Tuple
-
-from oop_ext.foundation.decorators import Override
-from oop_ext.foundation.odict import odict
+from typing import Any
+from typing import Callable
+from typing import Tuple
 
 from ._callback import Callback
+from oop_ext.foundation.decorators import Override
+from oop_ext.foundation.odict import odict
 
 
 class PriorityCallback(Callback):

--- a/src/oop_ext/foundation/callback/_shortcuts.py
+++ b/src/oop_ext/foundation/callback/_shortcuts.py
@@ -1,13 +1,18 @@
 # mypy: disallow-untyped-defs
 # mypy: disallow-any-decorated
 import weakref
-from typing import Union, Optional, Callable, Any, Tuple, Sequence
+from typing import Any
+from typing import Callable
+from typing import Optional
+from typing import Sequence
+from typing import Tuple
+from typing import Union
 
+from ._callback import _CallbackWrapper
+from ._callback import Callback
+from ._callback import GetClassForUnboundMethod
 from oop_ext.foundation.types_ import Method
 from oop_ext.foundation.weak_ref import WeakMethodRef
-
-
-from ._callback import Callback, GetClassForUnboundMethod, _CallbackWrapper
 
 
 def _CreateBeforeOrAfter(

--- a/src/oop_ext/foundation/callback/_tests/test_callback.py
+++ b/src/oop_ext/foundation/callback/_tests/test_callback.py
@@ -1,12 +1,20 @@
 import weakref
 from functools import partial
-from typing import Generator, Any, List
+from typing import Any
+from typing import Generator
+from typing import List
 
 import pytest
 
-from oop_ext.foundation.callback import After, Before, Callback, Callbacks, Remove
+from oop_ext.foundation.callback import After
+from oop_ext.foundation.callback import Before
+from oop_ext.foundation.callback import Callback
+from oop_ext.foundation.callback import Callbacks
+from oop_ext.foundation.callback import Remove
 from oop_ext.foundation.types_ import Null
-from oop_ext.foundation.weak_ref import GetWeakProxy, WeakMethodProxy, WeakMethodRef
+from oop_ext.foundation.weak_ref import GetWeakProxy
+from oop_ext.foundation.weak_ref import WeakMethodProxy
+from oop_ext.foundation.weak_ref import WeakMethodRef
 
 
 class _MyClass:

--- a/src/oop_ext/foundation/callback/_typed_callback.py
+++ b/src/oop_ext/foundation/callback/_typed_callback.py
@@ -16,10 +16,14 @@ Note the separate classes are needed for now, but if/when
 `pep-0646 <https://www.python.org/dev/peps/pep-0646>`__ lands, we should be able to
 implement the generic variants into ``Callback`` itself.
 """
+from typing import Callable
+from typing import Generic
+from typing import Sequence
+from typing import TYPE_CHECKING
+from typing import TypeVar
 
-from typing import Callable, Sequence, Generic, TypeVar, TYPE_CHECKING
-
-from ._callback import Callback, _UnregisterContext
+from ._callback import _UnregisterContext
+from ._callback import Callback
 
 T1 = TypeVar("T1")
 T2 = TypeVar("T2")

--- a/src/oop_ext/foundation/callback/single_call_callback.py
+++ b/src/oop_ext/foundation/callback/single_call_callback.py
@@ -1,6 +1,8 @@
 # mypy: disallow-untyped-defs
 # mypy: disallow-any-decorated
-from typing import Dict, Tuple, Callable
+from typing import Callable
+from typing import Dict
+from typing import Tuple
 
 from ._callback import Callback
 

--- a/src/oop_ext/foundation/decorators.py
+++ b/src/oop_ext/foundation/decorators.py
@@ -3,7 +3,13 @@
 Collection of decorator with ONLY standard library dependencies.
 """
 import warnings
-from typing import Callable, Optional, NoReturn, TypeVar, Any, TYPE_CHECKING, cast
+from typing import Any
+from typing import Callable
+from typing import cast
+from typing import NoReturn
+from typing import Optional
+from typing import TYPE_CHECKING
+from typing import TypeVar
 
 from oop_ext.foundation.is_frozen import IsDevelopment
 

--- a/src/oop_ext/foundation/immutable.py
+++ b/src/oop_ext/foundation/immutable.py
@@ -4,7 +4,14 @@
 
     USER: The cache-manager uses this module to generate a valid KEY for its cache dictionary.
 """
-from typing import Type, Any, Dict, Tuple, Callable, TypeVar, Generic, NoReturn
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import Generic
+from typing import NoReturn
+from typing import Tuple
+from typing import Type
+from typing import TypeVar
 
 _IMMUTABLE_TYPES = {float, int, str, bytes, bool, type(None)}
 

--- a/src/oop_ext/foundation/odict.py
+++ b/src/oop_ext/foundation/odict.py
@@ -1,6 +1,9 @@
 # mypy: disallow-untyped-defs
 import collections
-from typing import Any, Iterable, Hashable, Union
+from typing import Any
+from typing import Hashable
+from typing import Iterable
+from typing import Union
 
 
 class odict(collections.OrderedDict):

--- a/src/oop_ext/foundation/singleton.py
+++ b/src/oop_ext/foundation/singleton.py
@@ -1,6 +1,11 @@
 # mypy: disallow-untyped-defs
 import threading
-from typing import Type, Set, TypeVar, Generic, List, Optional
+from typing import Generic
+from typing import List
+from typing import Optional
+from typing import Set
+from typing import Type
+from typing import TypeVar
 
 
 class SingletonError(RuntimeError):

--- a/src/oop_ext/foundation/types_.py
+++ b/src/oop_ext/foundation/types_.py
@@ -2,7 +2,10 @@
 """
 Extensions to python native types.
 """
-from typing import TYPE_CHECKING, Any, NoReturn, Iterator
+from typing import Any
+from typing import Iterator
+from typing import NoReturn
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing_extensions import Literal

--- a/src/oop_ext/foundation/weak_ref.py
+++ b/src/oop_ext/foundation/weak_ref.py
@@ -1,22 +1,21 @@
 # mypy: disallow-untyped-defs
 import inspect
 import weakref
+from types import LambdaType
+from types import MethodType
+from typing import Any
+from typing import Callable
+from typing import cast
+from typing import Generic
+from typing import Iterable
+from typing import Iterator
+from typing import List
+from typing import Optional
+from typing import overload
+from typing import Set
+from typing import TypeVar
+from typing import Union
 from weakref import ReferenceType
-from types import LambdaType, MethodType
-from typing import (
-    Iterable,
-    Optional,
-    TypeVar,
-    Generic,
-    Iterator,
-    List,
-    Union,
-    Any,
-    Set,
-    cast,
-    overload,
-    Callable,
-)
 
 from oop_ext.foundation.decorators import Implements
 

--- a/src/oop_ext/interface/__init__.py
+++ b/src/oop_ext/interface/__init__.py
@@ -15,28 +15,25 @@
 
     If Foo doesn't implement some method from IFoo, an exception is raised at class creation time.
 """
-
 from ._adaptable_interface import IAdaptable
-from ._interface import (
-    AssertDeclaresInterface,
-    AssertImplements,
-    AssertImplementsFullChecking,
-    Attribute,
-    BadImplementationError,
-    CacheInterfaceAttrs,
-    DeclareClassImplements,
-    GetImplementedInterfaces,
-    GetProxy,
-    ImplementsInterface,
-    Interface,
-    InterfaceError,
-    InterfaceImplementationMetaClass,
-    InterfaceImplementorStub,
-    IsImplementation,
-    IsImplementationOfAny,
-    ReadOnlyAttribute,
-    TypeCheckingSupport,
-)
+from ._interface import AssertDeclaresInterface
+from ._interface import AssertImplements
+from ._interface import AssertImplementsFullChecking
+from ._interface import Attribute
+from ._interface import BadImplementationError
+from ._interface import CacheInterfaceAttrs
+from ._interface import DeclareClassImplements
+from ._interface import GetImplementedInterfaces
+from ._interface import GetProxy
+from ._interface import ImplementsInterface
+from ._interface import Interface
+from ._interface import InterfaceError
+from ._interface import InterfaceImplementationMetaClass
+from ._interface import InterfaceImplementorStub
+from ._interface import IsImplementation
+from ._interface import IsImplementationOfAny
+from ._interface import ReadOnlyAttribute
+from ._interface import TypeCheckingSupport
 
 
 __all__ = [

--- a/src/oop_ext/interface/_adaptable_interface.py
+++ b/src/oop_ext/interface/_adaptable_interface.py
@@ -1,5 +1,5 @@
-from ._interface import TypeCheckingSupport
 from ._interface import Interface
+from ._interface import TypeCheckingSupport
 
 
 class IAdaptable(Interface, TypeCheckingSupport):

--- a/src/oop_ext/interface/_interface.py
+++ b/src/oop_ext/interface/_interface.py
@@ -36,34 +36,31 @@ AssertImplements(impl, IMyCalculator)
 
 
 """
-
 import inspect
 import sys
 from contextlib import suppress
 from functools import lru_cache
-from typing import (
-    TypeVar,
-    Generic,
-    Type,
-    Any,
-    Sequence,
-    Tuple,
-    Optional,
-    Dict,
-    Set,
-    Union,
-    TYPE_CHECKING,
-    Callable,
-    List,
-    FrozenSet,
-    NoReturn,
-    cast,
-)
+from typing import Any
+from typing import Callable
+from typing import cast
+from typing import Dict
+from typing import FrozenSet
+from typing import Generic
+from typing import List
+from typing import NoReturn
+from typing import Optional
+from typing import Sequence
+from typing import Set
+from typing import Tuple
+from typing import Type
+from typing import TYPE_CHECKING
+from typing import TypeVar
+from typing import Union
 
+from oop_ext.foundation.cached_method import ImmutableParamsCachedMethod
 from oop_ext.foundation.decorators import Deprecated
 from oop_ext.foundation.is_frozen import IsDevelopment
 from oop_ext.foundation.types_ import Method
-from oop_ext.foundation.cached_method import ImmutableParamsCachedMethod
 
 if TYPE_CHECKING:
     from traceback import StackSummary

--- a/src/oop_ext/interface/_tests/test_interface.py
+++ b/src/oop_ext/interface/_tests/test_interface.py
@@ -4,26 +4,27 @@ from typing import List
 
 import pytest
 
-from oop_ext.foundation.decorators import Implements, Abstract, Override
-from oop_ext.foundation.types_ import Method, Null
-from oop_ext.interface import (
-    AssertImplements,
-    Attribute,
-    BadImplementationError,
-    DeclareClassImplements,
-    GetImplementedInterfaces,
-    IAdaptable,
-    ImplementsInterface,
-    Interface,
-    InterfaceError,
-    InterfaceImplementorStub,
-    IsImplementation,
-    ReadOnlyAttribute,
-    IsImplementationOfAny,
-    TypeCheckingSupport,
-    GetProxy,
-)
 from oop_ext import interface
+from oop_ext.foundation.decorators import Abstract
+from oop_ext.foundation.decorators import Implements
+from oop_ext.foundation.decorators import Override
+from oop_ext.foundation.types_ import Method
+from oop_ext.foundation.types_ import Null
+from oop_ext.interface import AssertImplements
+from oop_ext.interface import Attribute
+from oop_ext.interface import BadImplementationError
+from oop_ext.interface import DeclareClassImplements
+from oop_ext.interface import GetImplementedInterfaces
+from oop_ext.interface import GetProxy
+from oop_ext.interface import IAdaptable
+from oop_ext.interface import ImplementsInterface
+from oop_ext.interface import Interface
+from oop_ext.interface import InterfaceError
+from oop_ext.interface import InterfaceImplementorStub
+from oop_ext.interface import IsImplementation
+from oop_ext.interface import IsImplementationOfAny
+from oop_ext.interface import ReadOnlyAttribute
+from oop_ext.interface import TypeCheckingSupport
 
 
 class _InterfM1(Interface, TypeCheckingSupport):


### PR DESCRIPTION
This keeps imports organized automatically in a way to avoid conflicts. See [the docs](https://github.com/asottile/reorder_python_imports#why-this-style) for the rationale.