### PR TITLE
Add type checking for PriorityCallback

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,10 @@
 2.2.0 (UNRELEASED)
 ------------------
 
+* ``PriorityCallback`` now has type checking support, similar to ``Callback``, with type checked variants: ``PriorityCallback0``, ``PriorityCallback1``, etc (`#128`_).
 * Added support for Python 3.10.
+
+.. _#128: https://github.com/ESSS/oop-ext/pull/128
 
 2.1.0 (2021-03-19)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,7 @@
 ------------------
 
 * ``PriorityCallback`` now has type checking support, similar to ``Callback``, with type checked variants: ``PriorityCallback0``, ``PriorityCallback1``, etc (`#128`_).
+* ``UnregisterContext`` is now public, meant to be used in type annotations.
 * Added support for Python 3.10.
 
 .. _#128: https://github.com/ESSS/oop-ext/pull/128

--- a/docs/callbacks.rst
+++ b/docs/callbacks.rst
@@ -45,7 +45,11 @@ type checked for number of arguments and types.
 The method specialized signatures are only seen by the type checker, so using one of the specialized
 variants should have nearly zero runtime cost (only the cost of an empty subclass).
 
+.. versionadded:: 2.2.0
+
+``PriorityCallback`` has the same support, with ``PriorityCallback0``, ``PriorityCallback1``, ``PriorityCallback2``, etc.
+
 .. note::
-    The separate callback classes are needed for now, but if/when
-    `pep-0646 <https://www.python.org/dev/peps/pep-0646>`__ lands, we should be able to
-    implement the generic variants into ``Callback`` itself.
+    The separate callback classes are needed for now, but once we require Python 3.11
+    (`pep-0646 <https://www.python.org/dev/peps/pep-0646>`__, we should be able to
+    implement the generic variants into ``Callback`` and ``PriorityCallback`` themselves.

--- a/src/oop_ext/foundation/callback/__init__.py
+++ b/src/oop_ext/foundation/callback/__init__.py
@@ -11,9 +11,16 @@ from ._typed_callback import Callback2
 from ._typed_callback import Callback3
 from ._typed_callback import Callback4
 from ._typed_callback import Callback5
+from ._typed_callback import PriorityCallback0
+from ._typed_callback import PriorityCallback1
+from ._typed_callback import PriorityCallback2
+from ._typed_callback import PriorityCallback3
+from ._typed_callback import PriorityCallback4
+from ._typed_callback import PriorityCallback5
 
 __all__ = [
-    "Callbacks",
+    "After",
+    "Before",
     "Callback",
     "Callback0",
     "Callback1",
@@ -21,9 +28,14 @@ __all__ = [
     "Callback3",
     "Callback4",
     "Callback5",
+    "Callbacks",
     "PriorityCallback",
-    "After",
-    "Before",
+    "PriorityCallback0",
+    "PriorityCallback1",
+    "PriorityCallback2",
+    "PriorityCallback3",
+    "PriorityCallback4",
+    "PriorityCallback5",
     "Remove",
     "WrapForCallback",
 ]

--- a/src/oop_ext/foundation/callback/__init__.py
+++ b/src/oop_ext/foundation/callback/__init__.py
@@ -17,6 +17,7 @@ from ._typed_callback import PriorityCallback2
 from ._typed_callback import PriorityCallback3
 from ._typed_callback import PriorityCallback4
 from ._typed_callback import PriorityCallback5
+from ._typed_callback import UnregisterContext
 
 __all__ = [
     "After",
@@ -36,6 +37,7 @@ __all__ = [
     "PriorityCallback3",
     "PriorityCallback4",
     "PriorityCallback5",
+    "UnregisterContext",
     "Remove",
     "WrapForCallback",
 ]

--- a/src/oop_ext/foundation/callback/_callback.py
+++ b/src/oop_ext/foundation/callback/_callback.py
@@ -333,7 +333,7 @@ class Callback:
         self,
         func: Callable[..., Any],
         extra_args: Sequence[object] = _EXTRA_ARGS_CONSTANT,
-    ) -> "_UnregisterContext":
+    ) -> "UnregisterContext":
         """
         Registers a function in the callback.
 
@@ -365,7 +365,7 @@ class Callback:
         callbacks = self._callbacks
         callbacks.pop(key, None)  # Remove if it exists
         callbacks[key] = (self._GetInfo(func), extra_args)
-        return _UnregisterContext(self, key)
+        return UnregisterContext(self, key)
 
     def Contains(
         self,
@@ -478,12 +478,15 @@ def _IsCallableObject(func: object) -> bool:
 
 
 @attr.s(auto_attribs=True)
-class _UnregisterContext:
+class UnregisterContext:
     """
     Returned by Register(), supports easy removal of the callback later.
 
     Useful if many related callbacks are registered, so the contexts can be stored and used to
     unregister all the callbacks at once.
+
+    Note: this class was called `_UnregisterContext` initially, but for type-checking purposes
+    we made it public. The old name is still available for backward compatibility.
     """
 
     _callback: Callback
@@ -492,6 +495,10 @@ class _UnregisterContext:
     def Unregister(self) -> None:
         """Unregister the callback which returned this context"""
         self._callback._UnregisterByKey(self._key)
+
+
+# Backward compatibility alias.
+_UnregisterContext = UnregisterContext
 
 
 class _CallbackWrapper(Method):

--- a/src/oop_ext/foundation/callback/_callbacks.py
+++ b/src/oop_ext/foundation/callback/_callbacks.py
@@ -8,7 +8,7 @@ from typing import TypeVar
 from typing import cast
 
 from ._callback import Callback
-from ._callback import _UnregisterContext
+from ._callback import UnregisterContext
 from ._shortcuts import After
 from ._shortcuts import Before
 from ._shortcuts import Remove
@@ -44,7 +44,7 @@ class Callbacks:
 
     def __init__(self) -> None:
         self._function_callbacks: List[Tuple[Callable, Callable]] = []
-        self._contexts: List[_UnregisterContext] = []
+        self._contexts: List[UnregisterContext] = []
 
     def Before(
         self, sender: T, callback: Callable, *, sender_as_parameter: bool = False

--- a/src/oop_ext/foundation/callback/_priority_callback.py
+++ b/src/oop_ext/foundation/callback/_priority_callback.py
@@ -8,6 +8,7 @@ from oop_ext.foundation.decorators import Override
 from oop_ext.foundation.odict import odict
 
 from ._callback import Callback
+from ._callback import _UnregisterContext
 
 
 class PriorityCallback(Callback):
@@ -36,7 +37,7 @@ class PriorityCallback(Callback):
         func: Callable,
         extra_args: Tuple[object, ...] = Callback._EXTRA_ARGS_CONSTANT,
         priority: int = 5,
-    ) -> None:
+    ) -> _UnregisterContext:
         """
         Register a function in the callback.
         :param object func:
@@ -67,3 +68,4 @@ class PriorityCallback(Callback):
             i += 1
 
         callbacks.insert(i, key, (new_info, extra_args))
+        return _UnregisterContext(self, key)

--- a/src/oop_ext/foundation/callback/_priority_callback.py
+++ b/src/oop_ext/foundation/callback/_priority_callback.py
@@ -8,7 +8,7 @@ from oop_ext.foundation.decorators import Override
 from oop_ext.foundation.odict import odict
 
 from ._callback import Callback
-from ._callback import _UnregisterContext
+from ._callback import UnregisterContext
 
 
 class PriorityCallback(Callback):
@@ -37,7 +37,7 @@ class PriorityCallback(Callback):
         func: Callable,
         extra_args: Tuple[object, ...] = Callback._EXTRA_ARGS_CONSTANT,
         priority: int = 5,
-    ) -> _UnregisterContext:
+    ) -> UnregisterContext:
         """
         Register a function in the callback.
         :param object func:
@@ -68,4 +68,4 @@ class PriorityCallback(Callback):
             i += 1
 
         callbacks.insert(i, key, (new_info, extra_args))
-        return _UnregisterContext(self, key)
+        return UnregisterContext(self, key)

--- a/src/oop_ext/foundation/callback/_tests/test_priority_callback.py
+++ b/src/oop_ext/foundation/callback/_tests/test_priority_callback.py
@@ -1,8 +1,8 @@
-from oop_ext.foundation.callback import PriorityCallback
+from oop_ext.foundation.callback import PriorityCallback0
 
 
 def testPriorityCallback() -> None:
-    priority_callback = PriorityCallback()
+    priority_callback = PriorityCallback0()
 
     called = []
 
@@ -25,7 +25,12 @@ def testPriorityCallback() -> None:
     priority_callback.Register(OnCall2, priority=2)
     priority_callback.Register(OnCall3, priority=1)
     priority_callback.Register(OnCall4, priority=3)
-    priority_callback.Register(OnCall5, priority=2)
+    unregister5 = priority_callback.Register(OnCall5, priority=2)
 
     priority_callback()
     assert called == [3, 1, 2, 5, 4]
+
+    called.clear()
+    unregister5.Unregister()
+    priority_callback()
+    assert called == [3, 1, 2, 4]

--- a/src/oop_ext/foundation/callback/_typed_callback.py
+++ b/src/oop_ext/foundation/callback/_typed_callback.py
@@ -1,11 +1,11 @@
 # mypy: disallow-untyped-defs
 # mypy: disallow-any-decorated
 """
-Implement specializations of Callback which are type-checker friendly.
+Implement specializations of Callback and PriorityCallback which are type-checker friendly.
 
 Each new Callback variant (Callback0, Callback1, Callback2, etc) subclasses ``Callback``, but
 explicitly declare the signature of each method so it only accepts the correct number and type
-of arguments of the declaration.
+of arguments of the declaration. Same for `PriorityCallback`.
 
 Also, the method signatures are only seen by the type checker, so using one of the specialized
 variants should have nearly zero runtime cost (only the cost of an empty subclass).
@@ -24,6 +24,7 @@ from typing import TypeVar
 
 from ._callback import Callback
 from ._callback import _UnregisterContext
+from ._priority_callback import PriorityCallback
 
 T1 = TypeVar("T1")
 T2 = TypeVar("T2")
@@ -34,26 +35,25 @@ T5 = TypeVar("T5")
 
 class Callback0(Callback):
     if TYPE_CHECKING:
-        CallableType = Callable[[], None]
 
         def __call__(self) -> None:  # type:ignore[override]
             ...
 
         def Register(
             self,
-            func: CallableType,
+            func: Callable[[], None],
             extra_args: Sequence[object] = Callback._EXTRA_ARGS_CONSTANT,
         ) -> "_UnregisterContext": ...
 
         def Unregister(
             self,
-            func: CallableType,
+            func: Callable[[], None],
             extra_args: Sequence[object] = Callback._EXTRA_ARGS_CONSTANT,
         ) -> None: ...
 
         def Contains(
             self,
-            func: CallableType,
+            func: Callable[[], None],
             extra_args: Sequence[object] = Callback._EXTRA_ARGS_CONSTANT,
         ) -> bool: ...
 
@@ -170,6 +170,167 @@ class Callback5(Callback, Generic[T1, T2, T3, T4, T5]):
             self,
             func: Callable[[T1, T2, T3, T4, T5], None],
             extra_args: Sequence[object] = Callback._EXTRA_ARGS_CONSTANT,
+        ) -> "_UnregisterContext": ...
+
+        def Unregister(
+            self,
+            func: Callable[[T1, T2, T3, T4, T5], None],
+            extra_args: Sequence[object] = Callback._EXTRA_ARGS_CONSTANT,
+        ) -> None: ...
+
+        def Contains(
+            self,
+            func: Callable[[T1, T2, T3, T4, T5], None],
+            extra_args: Sequence[object] = Callback._EXTRA_ARGS_CONSTANT,
+        ) -> bool: ...
+
+
+class PriorityCallback0(PriorityCallback):
+    if TYPE_CHECKING:
+
+        def __call__(self) -> None:  # type:ignore[override]
+            ...
+
+        def Register(
+            self,
+            func: Callable[[], None],
+            extra_args: Sequence[object] = Callback._EXTRA_ARGS_CONSTANT,
+            priority: int = 5,
+        ) -> "_UnregisterContext": ...
+
+        def Unregister(
+            self,
+            func: Callable[[], None],
+            extra_args: Sequence[object] = Callback._EXTRA_ARGS_CONSTANT,
+        ) -> None: ...
+
+        def Contains(
+            self,
+            func: Callable[[], None],
+            extra_args: Sequence[object] = Callback._EXTRA_ARGS_CONSTANT,
+        ) -> bool: ...
+
+
+class PriorityCallback1(PriorityCallback, Generic[T1]):
+    if TYPE_CHECKING:
+
+        def __call__(  # type:ignore[override]
+            self, v1: T1
+        ) -> None: ...
+
+        def Register(
+            self,
+            func: Callable[[T1], None],
+            extra_args: Sequence[object] = Callback._EXTRA_ARGS_CONSTANT,
+            priority: int = 5,
+        ) -> "_UnregisterContext": ...
+
+        def Unregister(
+            self,
+            func: Callable[[T1], None],
+            extra_args: Sequence[object] = Callback._EXTRA_ARGS_CONSTANT,
+        ) -> None: ...
+
+        def Contains(
+            self,
+            func: Callable[[T1], None],
+            extra_args: Sequence[object] = Callback._EXTRA_ARGS_CONSTANT,
+        ) -> bool: ...
+
+
+class PriorityCallback2(PriorityCallback, Generic[T1, T2]):
+    if TYPE_CHECKING:
+
+        def __call__(  # type:ignore[override]
+            self, v1: T1, v2: T2
+        ) -> None: ...
+
+        def Register(
+            self,
+            func: Callable[[T1, T2], None],
+            extra_args: Sequence[object] = Callback._EXTRA_ARGS_CONSTANT,
+            priority: int = 5,
+        ) -> "_UnregisterContext": ...
+
+        def Unregister(
+            self,
+            func: Callable[[T1, T2], None],
+            extra_args: Sequence[object] = Callback._EXTRA_ARGS_CONSTANT,
+        ) -> None: ...
+
+        def Contains(
+            self,
+            func: Callable[[T1, T2], None],
+            extra_args: Sequence[object] = Callback._EXTRA_ARGS_CONSTANT,
+        ) -> bool: ...
+
+
+class PriorityCallback3(PriorityCallback, Generic[T1, T2, T3]):
+    if TYPE_CHECKING:
+
+        def __call__(  # type:ignore[override]
+            self, v1: T1, v2: T2, v3: T3
+        ) -> None: ...
+
+        def Register(
+            self,
+            func: Callable[[T1, T2, T3], None],
+            extra_args: Sequence[object] = Callback._EXTRA_ARGS_CONSTANT,
+            priority: int = 5,
+        ) -> "_UnregisterContext": ...
+
+        def Unregister(
+            self,
+            func: Callable[[T1, T2, T3], None],
+            extra_args: Sequence[object] = Callback._EXTRA_ARGS_CONSTANT,
+        ) -> None: ...
+
+        def Contains(
+            self,
+            func: Callable[[T1, T2, T3], None],
+            extra_args: Sequence[object] = Callback._EXTRA_ARGS_CONSTANT,
+        ) -> bool: ...
+
+
+class PriorityCallback4(PriorityCallback, Generic[T1, T2, T3, T4]):
+    if TYPE_CHECKING:
+
+        def __call__(  # type:ignore[override]
+            self, v1: T1, v2: T2, v3: T3, v4: T4
+        ) -> None: ...
+
+        def Register(
+            self,
+            func: Callable[[T1, T2, T3, T4], None],
+            extra_args: Sequence[object] = Callback._EXTRA_ARGS_CONSTANT,
+            priority: int = 5,
+        ) -> "_UnregisterContext": ...
+
+        def Unregister(
+            self,
+            func: Callable[[T1, T2, T3, T4], None],
+            extra_args: Sequence[object] = Callback._EXTRA_ARGS_CONSTANT,
+        ) -> None: ...
+
+        def Contains(
+            self,
+            func: Callable[[T1, T2, T3, T4], None],
+            extra_args: Sequence[object] = Callback._EXTRA_ARGS_CONSTANT,
+        ) -> bool: ...
+
+
+class PriorityCallback5(PriorityCallback, Generic[T1, T2, T3, T4, T5]):
+    if TYPE_CHECKING:
+
+        def __call__(  # type:ignore[override]
+            self, v1: T1, v2: T2, v3: T3, v4: T4, v5: T5
+        ) -> None: ...
+
+        def Register(
+            self,
+            func: Callable[[T1, T2, T2, T3, T4], None],
+            extra_args: Sequence[object] = Callback._EXTRA_ARGS_CONSTANT,
+            priority: int = 5,
         ) -> "_UnregisterContext": ...
 
         def Unregister(

--- a/src/oop_ext/foundation/callback/_typed_callback.py
+++ b/src/oop_ext/foundation/callback/_typed_callback.py
@@ -12,9 +12,8 @@ variants should have nearly zero runtime cost (only the cost of an empty subclas
 
 Implemented so far up to 5 arguments, more can be added if we think it is necessary.
 
-Note the separate classes are needed for now, but if/when
-`pep-0646 <https://www.python.org/dev/peps/pep-0646>`__ lands, we should be able to
-implement the generic variants into ``Callback`` itself.
+Note the separate classes are needed for now, but after Python 3.11, we should be able to
+implement the generic variants (`pep-0646 <https://www.python.org/dev/peps/pep-0646>`__) into ``Callback`` itself.
 """
 from typing import TYPE_CHECKING
 from typing import Callable
@@ -23,7 +22,7 @@ from typing import Sequence
 from typing import TypeVar
 
 from ._callback import Callback
-from ._callback import _UnregisterContext
+from ._callback import UnregisterContext
 from ._priority_callback import PriorityCallback
 
 T1 = TypeVar("T1")
@@ -43,7 +42,7 @@ class Callback0(Callback):
             self,
             func: Callable[[], None],
             extra_args: Sequence[object] = Callback._EXTRA_ARGS_CONSTANT,
-        ) -> "_UnregisterContext": ...
+        ) -> "UnregisterContext": ...
 
         def Unregister(
             self,
@@ -68,7 +67,7 @@ class Callback1(Callback, Generic[T1]):
             self,
             func: Callable[[T1], None],
             extra_args: Sequence[object] = Callback._EXTRA_ARGS_CONSTANT,
-        ) -> "_UnregisterContext": ...
+        ) -> "UnregisterContext": ...
 
         def Unregister(
             self,
@@ -93,7 +92,7 @@ class Callback2(Callback, Generic[T1, T2]):
             self,
             func: Callable[[T1, T2], None],
             extra_args: Sequence[object] = Callback._EXTRA_ARGS_CONSTANT,
-        ) -> "_UnregisterContext": ...
+        ) -> "UnregisterContext": ...
 
         def Unregister(
             self,
@@ -118,7 +117,7 @@ class Callback3(Callback, Generic[T1, T2, T3]):
             self,
             func: Callable[[T1, T2, T3], None],
             extra_args: Sequence[object] = Callback._EXTRA_ARGS_CONSTANT,
-        ) -> "_UnregisterContext": ...
+        ) -> "UnregisterContext": ...
 
         def Unregister(
             self,
@@ -144,7 +143,7 @@ class Callback4(Callback, Generic[T1, T2, T3, T4]):
             self,
             func: Callable[[T1, T2, T3, T4], None],
             extra_args: Sequence[object] = Callback._EXTRA_ARGS_CONSTANT,
-        ) -> "_UnregisterContext": ...
+        ) -> "UnregisterContext": ...
 
         def Unregister(
             self,
@@ -170,7 +169,7 @@ class Callback5(Callback, Generic[T1, T2, T3, T4, T5]):
             self,
             func: Callable[[T1, T2, T3, T4, T5], None],
             extra_args: Sequence[object] = Callback._EXTRA_ARGS_CONSTANT,
-        ) -> "_UnregisterContext": ...
+        ) -> "UnregisterContext": ...
 
         def Unregister(
             self,
@@ -196,7 +195,7 @@ class PriorityCallback0(PriorityCallback):
             func: Callable[[], None],
             extra_args: Sequence[object] = Callback._EXTRA_ARGS_CONSTANT,
             priority: int = 5,
-        ) -> "_UnregisterContext": ...
+        ) -> "UnregisterContext": ...
 
         def Unregister(
             self,
@@ -223,7 +222,7 @@ class PriorityCallback1(PriorityCallback, Generic[T1]):
             func: Callable[[T1], None],
             extra_args: Sequence[object] = Callback._EXTRA_ARGS_CONSTANT,
             priority: int = 5,
-        ) -> "_UnregisterContext": ...
+        ) -> "UnregisterContext": ...
 
         def Unregister(
             self,
@@ -250,7 +249,7 @@ class PriorityCallback2(PriorityCallback, Generic[T1, T2]):
             func: Callable[[T1, T2], None],
             extra_args: Sequence[object] = Callback._EXTRA_ARGS_CONSTANT,
             priority: int = 5,
-        ) -> "_UnregisterContext": ...
+        ) -> "UnregisterContext": ...
 
         def Unregister(
             self,
@@ -277,7 +276,7 @@ class PriorityCallback3(PriorityCallback, Generic[T1, T2, T3]):
             func: Callable[[T1, T2, T3], None],
             extra_args: Sequence[object] = Callback._EXTRA_ARGS_CONSTANT,
             priority: int = 5,
-        ) -> "_UnregisterContext": ...
+        ) -> "UnregisterContext": ...
 
         def Unregister(
             self,
@@ -304,7 +303,7 @@ class PriorityCallback4(PriorityCallback, Generic[T1, T2, T3, T4]):
             func: Callable[[T1, T2, T3, T4], None],
             extra_args: Sequence[object] = Callback._EXTRA_ARGS_CONSTANT,
             priority: int = 5,
-        ) -> "_UnregisterContext": ...
+        ) -> "UnregisterContext": ...
 
         def Unregister(
             self,
@@ -331,7 +330,7 @@ class PriorityCallback5(PriorityCallback, Generic[T1, T2, T3, T4, T5]):
             func: Callable[[T1, T2, T2, T3, T4], None],
             extra_args: Sequence[object] = Callback._EXTRA_ARGS_CONSTANT,
             priority: int = 5,
-        ) -> "_UnregisterContext": ...
+        ) -> "UnregisterContext": ...
 
         def Unregister(
             self,


### PR DESCRIPTION
Similar to `Callback`, we now have type checked variants: `PriorityCallback0`, `PriorityCallback1`, etc.