### PR TITLE
Prepare release 2.2.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,6 +64,10 @@ jobs:
         user: __token__
         password: ${{ secrets.pypi_token }}
         attestations: true
+    - name: GitHub Release
+      uses: softprops/action-gh-release@v2.0.8
+      with:
+        files: dist/*
 
   sonarcloud:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,7 @@
-2.2.0 (UNRELEASED)
-------------------
+2.2.0
+-----
+
+**Release**: 2024-10-24
 
 * ``PriorityCallback`` now has type checking support, similar to ``Callback``, with type checked variants: ``PriorityCallback0``, ``PriorityCallback1``, etc (`#128`_).
 * ``UnregisterContext`` is now public, meant to be used in type annotations.

--- a/README.rst
+++ b/README.rst
@@ -121,8 +121,7 @@ Release
 -------
 A reminder for the maintainers on how to make a new release.
 
-Note that the VERSION should follow the semantic versioning as X.Y.Z
-Ex.: v1.0.5
+Note that the VERSION should follow the semantic versioning as ``X.Y.Z`` (e.g. ``v1.0.5``).
 
 1. Create a ``release-VERSION`` branch from ``upstream/master``.
 2. Update ``CHANGELOG.rst``.


### PR DESCRIPTION
CHANGELOG: remove the release date from the header, this way we can have stable/predictable links to changelog entries.