### PR TITLE
Fix deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,3 +55,4 @@ jobs:
       with:
         files: dist/*
         tag_name: v${{ github.event.inputs.version }}
+        target_commitish: ${{ github.sha }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,9 +1,24 @@
+2.3.3
+-----
+
+**Release**: 2025-08-06
+
+* Fix type annotations:
+
+  * ``oop_ext.foundation.weak_ref.IsWeakProxy``.
+  * ``oop_ext.foundation.weak_ref.IsWeakRef``.
+  * ``oop_ext.foundation.weak_ref.GetWeakProxy``.
+
+
+
 2.3.2
 -----
 
 **Release**: 2025-08-05
 
-* Changed ``GetWeakProxy`` return type to ``T``. Unfortunately type-checkers understand that ``ProxyType[T]`` is not the same as ``T``, generating a lot of false negatives.
+**Broken Release**
+
+This version contains the incorrect patch -- nothing serious, just the ``master`` version instead of the expected patch.
 
 
 2.3.1
@@ -11,11 +26,9 @@
 
 **Release**: 2025-08-01
 
-* Fix type annotations:
+**Broken Release**
 
-  * ``oop_ext.foundation.weak_ref.IsWeakProxy``.
-  * ``oop_ext.foundation.weak_ref.IsWeakRef``.
-  * ``oop_ext.foundation.weak_ref.GetWeakProxy``.
+This version contains the incorrect patch -- nothing serious, just the ``master`` version instead of the expected patch.
 
 
 2.3.0


### PR DESCRIPTION
Contrary to what was expected, omitting the SHA for the release defaults to `master`, instead of the SHA that triggered the workflow.

This caused the last two releases to actually commit from `master`. 🤦 